### PR TITLE
[FEAT] 리포트 지출 상세 페이지 퍼블리싱

### DIFF
--- a/src/app/report/category/[categoryId]/page.tsx
+++ b/src/app/report/category/[categoryId]/page.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { use, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  getCategoryDetail,
+  type EmotionBadge,
+} from '@/features/report/mock/categoryDetailMockData';
+
+interface PageProps {
+  params: Promise<{ categoryId: string }>;
+}
+
+export default function CategoryDetailPage({ params }: PageProps) {
+  const router = useRouter();
+  const { categoryId } = use(params);
+  const decodedId = decodeURIComponent(categoryId);
+  const detail = getCategoryDetail(decodedId);
+
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth() + 1;
+
+  const [year, setYear] = useState(currentYear);
+  const [month, setMonth] = useState(detail?.month ?? currentMonth);
+
+  const isNextDisabled = year > currentYear || (year === currentYear && month >= currentMonth);
+  const monthLabel = year === currentYear ? `${month}월` : `${year}년 ${month}월`;
+
+  const handlePrev = () => {
+    if (month === 1) {
+      setYear((y) => y - 1);
+      setMonth(12);
+    } else {
+      setMonth((m) => m - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (isNextDisabled) return;
+    if (month === 12) {
+      setYear((y) => y + 1);
+      setMonth(1);
+    } else {
+      setMonth((m) => m + 1);
+    }
+  };
+
+  if (!detail) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center bg-white px-6">
+        <p className="text-[16px] text-[#73787E]">카테고리를 찾을 수 없어요.</p>
+        <button
+          onClick={() => router.back()}
+          className="mt-4 rounded-lg border border-[#E5E5E5] px-4 py-2 text-[14px]"
+        >
+          돌아가기
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col bg-white">
+      {/* 헤더 */}
+      <header className="flex flex-col gap-4.5 border-b-[5px] border-[#F7F8FA] px-4 pt-3 pb-5">
+        <button onClick={() => router.back()} aria-label="뒤로가기">
+          <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+            <path
+              d="M18 6L10 14L18 22"
+              stroke="#27282C"
+              strokeWidth="1.87"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+
+        <div className="flex items-center gap-2.5">
+          <button onClick={handlePrev} aria-label="이전 달">
+            <img
+              src="/icons/icon_arrow_left_fill.svg"
+              alt=""
+              width={26}
+              height={26}
+            />
+          </button>
+          <span
+            className={`text-center text-[22px] font-bold leading-normal tracking-[-0.55px] text-[#27282C] ${
+              year === currentYear ? 'w-13.5' : ''
+            }`}
+          >
+            {monthLabel}
+          </span>
+          <button onClick={handleNext} disabled={isNextDisabled} aria-label="다음 달">
+            <img
+              src="/icons/icon_arrow_right_fill.svg"
+              alt=""
+              width={26}
+              height={26}
+              className={isNextDisabled ? 'opacity-30' : 'opacity-100'}
+            />
+          </button>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <span className="flex h-18 w-12 items-center justify-center text-[48px] leading-none">
+            {detail.emoji}
+          </span>
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[18px] font-medium tracking-[-0.45px] text-[#474C52]">
+              {detail.name}
+            </span>
+            <span className="text-[28px] font-semibold tracking-[-0.7px] text-[#030303]">
+              {detail.totalAmount.toLocaleString()}원
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex flex-col pb-30">
+        {detail.groups.map((group, groupIdx) => (
+          <section
+            key={groupIdx}
+            className="flex flex-col gap-3.75 border-b border-[#E5E5E5] py-7.5"
+          >
+            {group.items.map((item, itemIdx) => (
+              <article key={item.id} className="flex flex-col gap-0.75 px-4">
+                {itemIdx === 0 && (
+                  <span className="text-[14px] font-medium tracking-[-0.35px] text-[#73787E]">
+                    {group.date}
+                  </span>
+                )}
+
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-1.5">
+                      {item.tags.map((tag, i) => (
+                        <span
+                          key={i}
+                          className="text-[16px] font-medium tracking-[-0.4px] text-[#13278A]"
+                        >
+                          #{tag}
+                        </span>
+                      ))}
+                    </div>
+                    <span className="h-3.5 w-px bg-[#D9D9D9]" />
+                    <div className="flex items-center gap-1.5">
+                      {item.emotions.map((emo, i) => (
+                        <EmotionDot key={i} emotion={emo} />
+                      ))}
+                    </div>
+                  </div>
+                  <span className="text-[20px] font-semibold tracking-[-0.5px] text-[#030303]">
+                    {item.amount.toLocaleString()}원
+                  </span>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <span className="text-[16px] font-medium tracking-[-0.4px] text-[#9FA4A8]">
+                    {item.memo ?? ''}
+                  </span>
+                  <span className="text-[16px] font-medium tracking-[-0.4px] text-[#9FA4A8]">
+                    {item.payment}
+                  </span>
+                </div>
+              </article>
+            ))}
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EmotionDot({ emotion }: { emotion: EmotionBadge }) {
+  return (
+    <span
+      className="flex size-5 items-center justify-center text-[18px] leading-none"
+      aria-label={emotion.name}
+    >
+      {emotion.emoji}
+    </span>
+  );
+}

--- a/src/app/report/emotion/[emotionId]/page.tsx
+++ b/src/app/report/emotion/[emotionId]/page.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { use, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getEmotionDetail } from '@/features/report/mock/emotionDetailMockData';
+
+interface PageProps {
+  params: Promise<{ emotionId: string }>;
+}
+
+export default function EmotionDetailPage({ params }: PageProps) {
+  const router = useRouter();
+  const { emotionId } = use(params);
+  const decodedId = decodeURIComponent(emotionId);
+  const detail = getEmotionDetail(decodedId);
+
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth() + 1;
+
+  const [year, setYear] = useState(currentYear);
+  const [month, setMonth] = useState(detail?.month ?? currentMonth);
+
+  const isNextDisabled = year > currentYear || (year === currentYear && month >= currentMonth);
+  const monthLabel = year === currentYear ? `${month}월` : `${year}년 ${month}월`;
+
+  const handlePrev = () => {
+    if (month === 1) {
+      setYear((y) => y - 1);
+      setMonth(12);
+    } else {
+      setMonth((m) => m - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (isNextDisabled) return;
+    if (month === 12) {
+      setYear((y) => y + 1);
+      setMonth(1);
+    } else {
+      setMonth((m) => m + 1);
+    }
+  };
+
+  if (!detail) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center bg-white px-6">
+        <p className="text-[16px] text-[#73787E]">감정을 찾을 수 없어요.</p>
+        <button
+          onClick={() => router.back()}
+          className="mt-4 rounded-lg border border-[#E5E5E5] px-4 py-2 text-[14px]"
+        >
+          돌아가기
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col bg-white">
+      {/* 헤더 */}
+      <header className="flex flex-col gap-4.5 border-b-[5px] border-[#F7F8FA] px-4 pt-3 pb-5">
+        <button onClick={() => router.back()} aria-label="뒤로가기">
+          <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+            <path
+              d="M18 6L10 14L18 22"
+              stroke="#27282C"
+              strokeWidth="1.87"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+
+        <div className="flex items-center gap-2.5">
+          <button onClick={handlePrev} aria-label="이전 달">
+            <img
+              src="/icons/icon_arrow_left_fill.svg"
+              alt=""
+              width={26}
+              height={26}
+            />
+          </button>
+          <span
+            className={`text-center text-[22px] font-bold leading-normal tracking-[-0.55px] text-[#27282C] ${
+              year === currentYear ? 'w-13.5' : ''
+            }`}
+          >
+            {monthLabel}
+          </span>
+          <button onClick={handleNext} disabled={isNextDisabled} aria-label="다음 달">
+            <img
+              src="/icons/icon_arrow_right_fill.svg"
+              alt=""
+              width={26}
+              height={26}
+              className={isNextDisabled ? 'opacity-30' : 'opacity-100'}
+            />
+          </button>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <span className="flex size-12 items-center justify-center text-[40px] leading-none">
+            {detail.emoji}
+          </span>
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[18px] font-medium tracking-[-0.45px] text-[#474C52]">
+              {detail.name}
+            </span>
+            <span className="text-[28px] font-semibold tracking-[-0.7px] text-[#030303]">
+              {detail.totalAmount.toLocaleString()}원
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex flex-col pb-30">
+        {detail.groups.map((group, groupIdx) => (
+          <section
+            key={groupIdx}
+            className="flex flex-col gap-7.5 border-b border-[#E5E5E5] py-7.5"
+          >
+            {group.items.map((item) => (
+              <article key={item.id} className="flex flex-col gap-0.75 px-4">
+                <span className="text-[14px] font-medium tracking-[-0.35px] text-[#73787E]">
+                  {group.date}
+                </span>
+                <div className="flex items-center justify-between">
+                  <span className="text-[18px] font-semibold tracking-[-0.45px] text-[#27282C]">
+                    {item.category}
+                  </span>
+                  <span className="text-[20px] font-semibold tracking-[-0.5px] text-[#030303]">
+                    {item.amount.toLocaleString()}원
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1.5">
+                    {item.tags.map((tag, i) => (
+                      <span
+                        key={i}
+                        className="text-[16px] font-medium tracking-[-0.4px] text-[#13278A]"
+                      >
+                        #{tag}
+                      </span>
+                    ))}
+                  </div>
+                  <span className="text-[16px] font-medium tracking-[-0.4px] text-[#9FA4A8]">
+                    {item.payment}
+                  </span>
+                </div>
+                {item.memo && (
+                  <span className="text-[16px] font-medium tracking-[-0.4px] text-[#9FA4A8]">
+                    {item.memo}
+                  </span>
+                )}
+              </article>
+            ))}
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/report/mock/categoryDetailMockData.ts
+++ b/src/features/report/mock/categoryDetailMockData.ts
@@ -1,0 +1,314 @@
+export interface EmotionBadge {
+  name: string;
+  emoji: string;
+  gradient: { from: string; to: string };
+}
+
+export interface ExpenseItem {
+  id: string;
+  tags: string[];
+  emotions: EmotionBadge[];
+  amount: number;
+  memo?: string;
+  payment: '카드' | '현금';
+}
+
+export interface ExpenseDateGroup {
+  date: string;
+  items: ExpenseItem[];
+}
+
+export interface CategoryDetail {
+  name: string;
+  emoji: string;
+  totalAmount: number;
+  month: number;
+  groups: ExpenseDateGroup[];
+}
+
+const emotions: Record<string, EmotionBadge> = {
+  boring: { name: '심심함', emoji: '😐', gradient: { from: '#EFE79C', to: '#CABE48' } },
+  empty: { name: '공허함', emoji: '😶', gradient: { from: '#DBE3D9', to: '#95A590' } },
+  tired: { name: '피곤함', emoji: '😩', gradient: { from: '#ECD9E7', to: '#A38F9E' } },
+  joy: { name: '기쁨', emoji: '😊', gradient: { from: '#FFD8DF', to: '#FFABBA' } },
+  excited: { name: '설렘', emoji: '🥰', gradient: { from: '#FFCAC5', to: '#FF897E' } },
+  thankful: { name: '고마움', emoji: '🥺', gradient: { from: '#FFA7B1', to: '#FF6B7C' } },
+  impulse: { name: '충동', emoji: '😵', gradient: { from: '#FFA0CB', to: '#FF4F9E' } },
+  anxious: { name: '불안함', emoji: '😰', gradient: { from: '#E590F5', to: '#A046B1' } },
+  proud: { name: '뿌듯함', emoji: '😎', gradient: { from: '#FFC2A5', to: '#FF874F' } },
+  gloomy: { name: '우울함', emoji: '😔', gradient: { from: '#C8C8C8', to: '#7F888B' } },
+  sad: { name: '슬픔', emoji: '😢', gradient: { from: '#BEEAF7', to: '#7BCDE6' } },
+};
+
+export const categoryDetailMockData: Record<string, CategoryDetail> = {
+  식비: {
+    name: '식비',
+    emoji: '🍔',
+    totalAmount: 592_000,
+    month: 4,
+    groups: [
+      {
+        date: '2일 목요일',
+        items: [
+          {
+            id: 'f-1',
+            tags: ['기분전환', '보상심리'],
+            emotions: [emotions.boring, emotions.empty],
+            amount: 68_000,
+            memo: '케이크',
+            payment: '카드',
+          },
+          {
+            id: 'f-2',
+            tags: ['피로회복', '기타'],
+            emotions: [emotions.tired, emotions.joy],
+            amount: 42_000,
+            payment: '현금',
+          },
+        ],
+      },
+      {
+        date: '3일 금요일',
+        items: [
+          {
+            id: 'f-3',
+            tags: ['기분전환'],
+            emotions: [emotions.excited, emotions.joy],
+            amount: 55_000,
+            memo: '하이디라오',
+            payment: '카드',
+          },
+          {
+            id: 'f-4',
+            tags: ['기분전환'],
+            emotions: [emotions.excited, emotions.joy],
+            amount: 28_000,
+            payment: '카드',
+          },
+        ],
+      },
+      {
+        date: '4일 토요일',
+        items: [
+          {
+            id: 'f-5',
+            tags: ['약속'],
+            emotions: [emotions.thankful],
+            amount: 74_000,
+            payment: '카드',
+          },
+          {
+            id: 'f-6',
+            tags: ['충동소비', '기분전환'],
+            emotions: [emotions.impulse, emotions.anxious],
+            amount: 63_000,
+            payment: '카드',
+          },
+        ],
+      },
+      {
+        date: '5일 월요일',
+        items: [
+          {
+            id: 'f-7',
+            tags: ['필요'],
+            emotions: [emotions.proud],
+            amount: 48_000,
+            payment: '현금',
+          },
+          {
+            id: 'f-8',
+            tags: ['충동소비', '기분전환'],
+            emotions: [emotions.impulse, emotions.gloomy],
+            amount: 86_000,
+            memo: '대학교 친구들과 모임',
+            payment: '카드',
+          },
+          {
+            id: 'f-9',
+            tags: ['피로회복'],
+            emotions: [emotions.tired, emotions.sad],
+            amount: 23_000,
+            payment: '현금',
+          },
+        ],
+      },
+      {
+        date: '6일 화요일',
+        items: [
+          {
+            id: 'f-10',
+            tags: ['피로회복'],
+            emotions: [emotions.tired],
+            amount: 105_000,
+            payment: '카드',
+          },
+        ],
+      },
+    ],
+  },
+  경조사: {
+    name: '경조사',
+    emoji: '🎁',
+    totalAmount: 254_000,
+    month: 4,
+    groups: [
+      {
+        date: '5일 월요일',
+        items: [
+          {
+            id: 'c-1',
+            tags: ['약속'],
+            emotions: [emotions.thankful, emotions.joy],
+            amount: 100_000,
+            memo: '결혼식 축의금',
+            payment: '현금',
+          },
+        ],
+      },
+      {
+        date: '12일 월요일',
+        items: [
+          {
+            id: 'c-2',
+            tags: ['약속', '필요'],
+            emotions: [emotions.proud],
+            amount: 80_000,
+            memo: '돌잔치 선물',
+            payment: '카드',
+          },
+        ],
+      },
+      {
+        date: '20일 화요일',
+        items: [
+          {
+            id: 'c-3',
+            tags: ['약속'],
+            emotions: [emotions.sad, emotions.thankful],
+            amount: 74_000,
+            memo: '조의금',
+            payment: '현금',
+          },
+        ],
+      },
+    ],
+  },
+  의료: {
+    name: '의료',
+    emoji: '💊',
+    totalAmount: 84_000,
+    month: 4,
+    groups: [
+      {
+        date: '8일 목요일',
+        items: [
+          {
+            id: 'm-1',
+            tags: ['필요', '피로회복'],
+            emotions: [emotions.tired, emotions.anxious],
+            amount: 45_000,
+            memo: '내과 진료',
+            payment: '카드',
+          },
+        ],
+      },
+      {
+        date: '15일 목요일',
+        items: [
+          {
+            id: 'm-2',
+            tags: ['필요'],
+            emotions: [emotions.tired],
+            amount: 39_000,
+            memo: '처방약',
+            payment: '카드',
+          },
+        ],
+      },
+    ],
+  },
+  뷰티: {
+    name: '뷰티',
+    emoji: '💄',
+    totalAmount: 42_000,
+    month: 4,
+    groups: [
+      {
+        date: '10일 토요일',
+        items: [
+          {
+            id: 'b-1',
+            tags: ['기분전환', '보상심리'],
+            emotions: [emotions.excited, emotions.joy],
+            amount: 28_000,
+            memo: '립스틱',
+            payment: '카드',
+          },
+        ],
+      },
+      {
+        date: '17일 토요일',
+        items: [
+          {
+            id: 'b-2',
+            tags: ['기분전환'],
+            emotions: [emotions.joy],
+            amount: 14_000,
+            payment: '카드',
+          },
+        ],
+      },
+    ],
+  },
+  교통: {
+    name: '교통',
+    emoji: '🚌',
+    totalAmount: 31_000,
+    month: 4,
+    groups: [
+      {
+        date: '3일 금요일',
+        items: [
+          {
+            id: 't-1',
+            tags: ['필요'],
+            emotions: [emotions.tired],
+            amount: 15_000,
+            memo: '택시비',
+            payment: '카드',
+          },
+        ],
+      },
+      {
+        date: '11일 일요일',
+        items: [
+          {
+            id: 't-2',
+            tags: ['필요'],
+            emotions: [emotions.proud],
+            amount: 10_000,
+            memo: 'KTX 편도',
+            payment: '카드',
+          },
+        ],
+      },
+      {
+        date: '19일 월요일',
+        items: [
+          {
+            id: 't-3',
+            tags: ['필요'],
+            emotions: [emotions.empty],
+            amount: 6_000,
+            payment: '카드',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export function getCategoryDetail(categoryId: string): CategoryDetail | null {
+  return categoryDetailMockData[categoryId] ?? null;
+}

--- a/src/features/report/mock/emotionDetailMockData.ts
+++ b/src/features/report/mock/emotionDetailMockData.ts
@@ -1,0 +1,267 @@
+export interface EmotionExpenseItem {
+  id: string;
+  category: string;
+  amount: number;
+  tags: string[];
+  memo?: string;
+  payment: '카드' | '현금';
+}
+
+export interface EmotionExpenseDateGroup {
+  date: string;
+  items: EmotionExpenseItem[];
+}
+
+export interface EmotionDetail {
+  name: string;
+  emoji: string;
+  totalAmount: number;
+  month: number;
+  groups: EmotionExpenseDateGroup[];
+}
+
+export const emotionDetailMockData: Record<string, EmotionDetail> = {
+  우울함: {
+    name: '우울함',
+    emoji: '😔',
+    totalAmount: 342_000,
+    month: 4,
+    groups: [
+      {
+        date: '2일 목요일',
+        items: [
+          {
+            id: 'g-1',
+            category: '의류',
+            amount: 68_000,
+            tags: ['기분전환', '보상심리'],
+            memo: '일본 여행 코디',
+            payment: '현금',
+          },
+          {
+            id: 'g-2',
+            category: '카페',
+            amount: 18_000,
+            tags: ['피로회복'],
+            payment: '카드',
+          },
+        ],
+      },
+      {
+        date: '4일 토요일',
+        items: [
+          {
+            id: 'g-3',
+            category: '식비',
+            amount: 54_000,
+            tags: ['기분전환', '약속'],
+            memo: '고등학교 동창 정기 모임',
+            payment: '카드',
+          },
+          {
+            id: 'g-4',
+            category: '뷰티',
+            amount: 47_000,
+            tags: ['기분전환', '충동소비'],
+            payment: '카드',
+          },
+        ],
+      },
+      {
+        date: '5일 일요일',
+        items: [
+          {
+            id: 'g-5',
+            category: '생필품',
+            amount: 29_000,
+            tags: ['필요', '할인'],
+            memo: '피규어 신상 구매',
+            payment: '현금',
+          },
+        ],
+      },
+      {
+        date: '6일 월요일',
+        items: [
+          {
+            id: 'g-6',
+            category: '문화생활',
+            amount: 82_000,
+            tags: ['충동소비', '기분전환'],
+            memo: '해서웨이 공연 관람',
+            payment: '현금',
+          },
+          {
+            id: 'g-7',
+            category: '카페',
+            amount: 14_000,
+            tags: ['피로회복'],
+            payment: '현금',
+          },
+        ],
+      },
+      {
+        date: '8일 수요일',
+        items: [
+          {
+            id: 'g-8',
+            category: '식비',
+            amount: 30_000,
+            tags: ['보상심리'],
+            payment: '카드',
+          },
+        ],
+      },
+    ],
+  },
+  충동: {
+    name: '충동',
+    emoji: '😵',
+    totalAmount: 145_000,
+    month: 4,
+    groups: [
+      {
+        date: '3일 금요일',
+        items: [
+          {
+            id: 'i-1',
+            category: '뷰티',
+            amount: 58_000,
+            tags: ['충동소비'],
+            memo: '립스틱 신상',
+            payment: '카드',
+          },
+        ],
+      },
+      {
+        date: '10일 토요일',
+        items: [
+          {
+            id: 'i-2',
+            category: '의류',
+            amount: 45_000,
+            tags: ['충동소비', '할인'],
+            payment: '카드',
+          },
+          {
+            id: 'i-3',
+            category: '카페',
+            amount: 22_000,
+            tags: ['기분전환'],
+            payment: '현금',
+          },
+        ],
+      },
+      {
+        date: '15일 목요일',
+        items: [
+          {
+            id: 'i-4',
+            category: '생필품',
+            amount: 20_000,
+            tags: ['충동소비'],
+            payment: '카드',
+          },
+        ],
+      },
+    ],
+  },
+  불안함: {
+    name: '불안함',
+    emoji: '😟',
+    totalAmount: 95_000,
+    month: 4,
+    groups: [
+      {
+        date: '7일 수요일',
+        items: [
+          {
+            id: 'a-1',
+            category: '의료',
+            amount: 50_000,
+            tags: ['필요'],
+            memo: '건강검진',
+            payment: '카드',
+          },
+        ],
+      },
+      {
+        date: '14일 수요일',
+        items: [
+          {
+            id: 'a-2',
+            category: '식비',
+            amount: 28_000,
+            tags: ['보상심리'],
+            payment: '카드',
+          },
+          {
+            id: 'a-3',
+            category: '카페',
+            amount: 17_000,
+            tags: ['기분전환'],
+            payment: '현금',
+          },
+        ],
+      },
+    ],
+  },
+  스트레스: {
+    name: '스트레스',
+    emoji: '😫',
+    totalAmount: 32_000,
+    month: 4,
+    groups: [
+      {
+        date: '9일 금요일',
+        items: [
+          {
+            id: 's-1',
+            category: '카페',
+            amount: 12_000,
+            tags: ['기분전환'],
+            payment: '카드',
+          },
+        ],
+      },
+      {
+        date: '16일 금요일',
+        items: [
+          {
+            id: 's-2',
+            category: '식비',
+            amount: 20_000,
+            tags: ['보상심리'],
+            memo: '야식 배달',
+            payment: '카드',
+          },
+        ],
+      },
+    ],
+  },
+  외로움: {
+    name: '외로움',
+    emoji: '😢',
+    totalAmount: 13_000,
+    month: 4,
+    groups: [
+      {
+        date: '18일 일요일',
+        items: [
+          {
+            id: 'l-1',
+            category: '카페',
+            amount: 13_000,
+            tags: ['기분전환'],
+            memo: '혼자 브런치',
+            payment: '카드',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export function getEmotionDetail(emotionId: string): EmotionDetail | null {
+  return emotionDetailMockData[emotionId] ?? null;
+}

--- a/src/features/report/ui/CategoryChart.tsx
+++ b/src/features/report/ui/CategoryChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import type { CategoryItem } from '@/features/report/mock/reportMockData';
 
 interface CategoryChartProps {
@@ -81,7 +82,11 @@ export default function CategoryChart({ summary, categories }: CategoryChartProp
 
       <div className="flex flex-col gap-3.75">
         {visibleCategories.map((cat) => (
-          <div key={cat.name} className="flex items-center justify-between">
+          <Link
+            key={cat.name}
+            href={`/report/category/${encodeURIComponent(cat.name)}`}
+            className="flex items-center justify-between"
+          >
             <div className="flex items-center gap-2.5">
               <span
                 className="block size-2 rounded-full"
@@ -113,7 +118,7 @@ export default function CategoryChart({ summary, categories }: CategoryChartProp
                 />
               </svg>
             </div>
-          </div>
+          </Link>
         ))}
       </div>
 

--- a/src/features/report/ui/EmotionList.tsx
+++ b/src/features/report/ui/EmotionList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import type { EmotionItem } from '@/features/report/mock/reportMockData';
 
 interface EmotionListProps {
@@ -25,7 +26,11 @@ export default function EmotionList({ summary, emotions }: EmotionListProps) {
 
       <div className="flex flex-col gap-3.75">
         {visibleEmotions.map((item, index) => (
-          <div key={`${item.rank}-${item.name}-${index}`} className="flex items-center justify-between">
+          <Link
+            key={`${item.rank}-${item.name}-${index}`}
+            href={`/report/emotion/${encodeURIComponent(item.name)}`}
+            className="flex items-center justify-between"
+          >
             <div className="flex items-center gap-3.75">
               <span className="w-4.5 text-center text-[18px] font-medium tracking-[-0.45px] text-[#1C1D1F]">
                 {item.rank}
@@ -51,7 +56,7 @@ export default function EmotionList({ summary, emotions }: EmotionListProps) {
                 />
               </svg>
             </div>
-          </div>
+          </Link>
         ))}
       </div>
 


### PR DESCRIPTION
## 작업 내용    
                                              
  - 리포트 카테고리별 지출 상세 페이지 구현
  - 리포트 감정별 지출 상세 페이지 구현                  
                                                                  
  ## 파일 구조                                                    
                                                                  
  ### src/app/report/                                             
  - category/[categoryId]/page.tsx: 카테고리별 지출 상세 페이지   
  - emotion/[emotionId]/page.tsx: 감정별 지출 상세 페이지
                                              
  ### src/features/report/mock/           
  - categoryDetailMockData.ts: 카테고리 상세 mock (식비/경조사/의료/뷰티/교통)                                    
  - emotionDetailMockData.ts: 감정 상세 mock (우울함/충동/불안함/스트레스/외로움)                            
                                                                  
  ### src/features/report/ui/
  - CategoryChart.tsx: 카테고리 클릭 시 상세로 라우팅 (Link 추가) 
  - EmotionList.tsx: 감정 클릭 시 상세로 라우팅 (Link 추가)
                                                                  
  ## 참고                                 
                                                                  
  - 감정 아이콘 추후 SVG로 교체 예정                            
  - 카테고리·감정 mock 데이터는 `reportMockData.ts`의 목록과 독립적으로 관리 중, 추후 통합 예정