### PR TITLE
[FIX] 가계부 캘린더 페이지 UI 보완 및 라우팅 수정

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,25 +1,26 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import CalendarHeader from '@/features/calendar/ui/CalendarHeader';
 import CalendarGrid from '@/features/calendar/ui/CalendarGrid';
 import DateBottomSheet from '@/features/calendar/ui/DateBottomSheet';
+import {
+  getCalendarDailyData,
+  getDailyAmounts,
+  getMonthlyTotals,
+} from '@/features/calendar/mock/calendarMockData';
 
 export default function CalendarPage() {
+  const router = useRouter();
   const today = new Date();
   const [year, setYear] = useState(today.getFullYear());
   const [month, setMonth] = useState(today.getMonth());
   const [selectedDay, setSelectedDay] = useState<number | null>(null);
 
-  const dummyData = {
-    income: 50000,
-    expense: 50000,
-    expenseItems: [
-      { category: '카페', tags: ['기분전환', '보상심리'], amount: 12000, paymentMethod: '현금' },
-      { category: '생필품', tags: ['필요'], amount: 24000, paymentMethod: '체크카드' },
-      { category: '식비', tags: ['약속'], amount: 16000, paymentMethod: '체크카드' },
-    ],
-  };
+  const dailyAmounts = getDailyAmounts();
+  const dayData = getCalendarDailyData(selectedDay);
+  const monthlyTotals = getMonthlyTotals();
 
   const handlePrevMonth = () => {
     if (month === 0) {
@@ -43,15 +44,17 @@ export default function CalendarPage() {
     <div className="flex flex-1 flex-col">
       {/* 상단 헤더 (공용 컴포넌트로 변경예정) */}
       <header className="flex h-14 items-center justify-between px-4">
-        <button>
+        <button onClick={() => router.push('/')} aria-label="메인으로 이동">
           <img
             src="/icons/icon_arrow_left.svg"
-            alt="뒤로가기"
+            alt=""
             width={28}
             height={28}
           />
         </button>
-        <h1 className="text-base font-bold">캘린더</h1>
+        <h1 className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
+          캘린더
+        </h1>
         <div className="w-6" />
       </header>
 
@@ -61,6 +64,9 @@ export default function CalendarPage() {
           month={month}
           onPrevMonth={handlePrevMonth}
           onNextMonth={handleNextMonth}
+          income={monthlyTotals.income}
+          expense={monthlyTotals.expense}
+          balance={monthlyTotals.balance}
         />
       </div>
 
@@ -69,12 +75,18 @@ export default function CalendarPage() {
           year={year}
           month={month}
           onDateClick={(day) => setSelectedDay(day)}
+          dailyAmounts={dailyAmounts}
+          selectedDay={selectedDay}
         />
       </div>
 
       <div className="fixed bottom-0 left-1/2 flex w-full max-w-md -translate-x-1/2 justify-end">
-        <button className="mb-46.75 mr-7.5 z-40 flex size-14.5 items-center justify-center rounded-full bg-[#13278A] p-2.75 shadow-[2px_3px_7px_0px_rgba(49,49,49,0.3)]">
-          <img src="/icons/icon_plus.svg" alt="지출 추가" width={36} height={36} />
+        <button
+          onClick={() => router.push('/record?type=expense')}
+          aria-label="지출 추가"
+          className="z-40 mb-32.5 mr-4 flex size-14.5 items-center justify-center rounded-full bg-[#13278A] p-2.75 shadow-[2px_3px_7px_0px_rgba(49,49,49,0.3)]"
+        >
+          <img src="/icons/icon_plus.svg" alt="" width={36} height={36} />
         </button>
       </div>
 
@@ -83,9 +95,9 @@ export default function CalendarPage() {
           date={selectedDay}
           month={month}
           year={year}
-          income={dummyData.income}
-          expense={dummyData.expense}
-          expenseItems={dummyData.expenseItems}
+          income={dayData.income}
+          expense={dayData.expense}
+          expenseItems={dayData.expenseItems}
           onClose={() => setSelectedDay(null)}
         />
       )}

--- a/src/features/calendar/mock/calendarMockData.ts
+++ b/src/features/calendar/mock/calendarMockData.ts
@@ -1,0 +1,77 @@
+export interface CalendarExpenseItem {
+  category: string;
+  tags: string[];
+  amount: number;
+  paymentMethod: string;
+  memo?: string;
+}
+
+export interface CalendarDailyData {
+  income: number;
+  expense: number;
+  expenseItems: CalendarExpenseItem[];
+}
+
+export const dailyCalendarMock: Record<number, CalendarDailyData> = {
+  2: {
+    income: 200000,
+    expense: 75000,
+    expenseItems: [
+      { category: '식비', tags: ['약속', '보상심리'], amount: 28000, paymentMethod: '카드', memo: '친구 생일 저녁' },
+      { category: '카페', tags: ['기분전환'], amount: 12000, paymentMethod: '현금' },
+      { category: '디저트', tags: ['보상심리'], amount: 9000, paymentMethod: '카드', memo: '두쫀쿠' },
+      { category: '생필품', tags: ['필요'], amount: 14000, paymentMethod: '체크카드' },
+      { category: '교통', tags: ['피로회복'], amount: 8000, paymentMethod: '카드' },
+      { category: '편의점', tags: ['충동소비'], amount: 4000, paymentMethod: '현금', memo: '간식' },
+    ],
+  },
+  7: {
+    income: 0,
+    expense: 50000,
+    expenseItems: [
+      { category: '카페', tags: ['기분전환'], amount: 25000, paymentMethod: '카드', memo: '스타벅스' },
+      { category: '생필품', tags: ['필요'], amount: 25000, paymentMethod: '체크카드', memo: '다이소' },
+    ],
+  },
+  10: {
+    income: 0,
+    expense: 42000,
+    expenseItems: [
+      { category: '식비', tags: ['보상심리'], amount: 42000, paymentMethod: '카드', memo: '혼밥' },
+    ],
+  },
+};
+
+export const emptyCalendarData: CalendarDailyData = {
+  income: 0,
+  expense: 0,
+  expenseItems: [],
+};
+
+export function getCalendarDailyData(day: number | null): CalendarDailyData {
+  if (day === null) return emptyCalendarData;
+  return dailyCalendarMock[day] ?? emptyCalendarData;
+}
+
+export function getDailyAmounts(): Record<number, { income: number; expense: number }> {
+  return Object.fromEntries(
+    Object.entries(dailyCalendarMock).map(([day, data]) => [
+      day,
+      { income: data.income, expense: data.expense },
+    ])
+  );
+}
+
+export function getMonthlyTotals(): { income: number; expense: number; balance: number } {
+  const totals = Object.values(dailyCalendarMock).reduce(
+    (acc, data) => ({
+      income: acc.income + data.income,
+      expense: acc.expense + data.expense,
+    }),
+    { income: 0, expense: 0 }
+  );
+  return {
+    ...totals,
+    balance: totals.income - totals.expense,
+  };
+}

--- a/src/features/calendar/ui/CalendarGrid.tsx
+++ b/src/features/calendar/ui/CalendarGrid.tsx
@@ -23,13 +23,26 @@ function getCalendarDates(year: number, month: number) {
   return dates;
 }
 
+export interface DailyAmount {
+  income?: number;
+  expense?: number;
+}
+
 interface CalendarGridProps {
   year: number;
   month: number;
   onDateClick?: (day: number) => void;
+  dailyAmounts?: Record<number, DailyAmount>;
+  selectedDay?: number | null;
 }
 
-export default function CalendarGrid({ year, month, onDateClick }: CalendarGridProps) {
+export default function CalendarGrid({
+  year,
+  month,
+  onDateClick,
+  dailyAmounts = {},
+  selectedDay = null,
+}: CalendarGridProps) {
   const today = new Date();
   const isCurrentMonth =
     year === today.getFullYear() && month === today.getMonth();
@@ -51,28 +64,56 @@ export default function CalendarGrid({ year, month, onDateClick }: CalendarGridP
       </div>
 
       <div className="grid flex-1 auto-rows-fr grid-cols-7">
-        {dates.map((date, index) => (
-          <div
-            key={index}
-            onClick={() => date.isCurrentMonth && onDateClick?.(date.day)}
-            className={`flex flex-col overflow-hidden px-1.25 py-2 ${
-              date.isCurrentMonth ? 'cursor-pointer' : ''
-            }`}
-          >
+        {dates.map((date, index) => {
+          const amounts = date.isCurrentMonth ? dailyAmounts[date.day] : undefined;
+          const isSelected = date.isCurrentMonth && date.day === selectedDay;
+          const isToday = date.isCurrentMonth && date.day === todayDate;
+          const otherDateSelected =
+            selectedDay !== null && selectedDay !== todayDate;
 
+          let dayClass = '';
+          if (isSelected) {
+            dayClass = 'rounded-[25px] bg-[#13278A] text-white';
+          } else if (isToday && otherDateSelected) {
+            dayClass = 'rounded-[25px] bg-[#E5E5E5] text-[#1C1D1F]';
+          } else if (isToday) {
+            dayClass = 'rounded-[25px] bg-[#13278A] text-white';
+          } else if (date.isCurrentMonth) {
+            dayClass = 'text-[#1C1D1F]';
+          } else {
+            dayClass = 'text-[#9FA4A8]';
+          }
+
+          return (
             <div
-              className={`flex w-5.25 items-center justify-center text-[14px] font-medium leading-normal tracking-[-0.35px] ${
-                date.isCurrentMonth && date.day === todayDate
-                  ? 'rounded-[25px] bg-[#13278A] text-white'
-                  : date.isCurrentMonth
-                    ? 'text-[#1C1D1F]'
-                    : 'text-[#9FA4A8]'
+              key={index}
+              onClick={() => date.isCurrentMonth && onDateClick?.(date.day)}
+              className={`flex flex-col gap-1.25 overflow-hidden px-1.25 py-2 ${
+                date.isCurrentMonth ? 'cursor-pointer' : ''
               }`}
             >
-              {date.day}
+              <div
+                className={`flex w-5.25 items-center justify-center text-[14px] font-medium leading-normal tracking-[-0.35px] ${dayClass}`}
+              >
+                {date.day}
+              </div>
+              {amounts && (
+                <div className="flex flex-col gap-1.25 text-[12px] font-medium leading-normal tracking-[-0.3px]">
+                  {amounts.income ? (
+                    <span className="text-[#030303]">
+                      +{amounts.income.toLocaleString()}
+                    </span>
+                  ) : null}
+                  {amounts.expense ? (
+                    <span className="text-[#EB1C1C]">
+                      -{amounts.expense.toLocaleString()}
+                    </span>
+                  ) : null}
+                </div>
+              )}
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/src/features/calendar/ui/CalendarHeader.tsx
+++ b/src/features/calendar/ui/CalendarHeader.tsx
@@ -3,6 +3,9 @@ interface CalendarHeaderProps {
   month: number;
   onPrevMonth: () => void;
   onNextMonth: () => void;
+  income: number;
+  expense: number;
+  balance: number;
 }
 
 export default function CalendarHeader({
@@ -10,6 +13,9 @@ export default function CalendarHeader({
   month,
   onPrevMonth,
   onNextMonth,
+  income,
+  expense,
+  balance,
 }: CalendarHeaderProps) {
   const today = new Date();
   const isCurrentMonth =
@@ -55,8 +61,8 @@ export default function CalendarHeader({
             <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#73787E]">
               수입
             </p>
-            <p className="whitespace-nowrap text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#13278A]">
-              300,000원
+            <p className="whitespace-nowrap text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#030303]">
+              {income.toLocaleString()}원
             </p>
           </div>
           <div className="flex w-29 flex-col items-center px-2.5 py-0.75 pb-1.5">
@@ -64,7 +70,7 @@ export default function CalendarHeader({
               지출
             </p>
             <p className="whitespace-nowrap text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#EB1C1C]">
-              200,000원
+              {expense.toLocaleString()}원
             </p>
           </div>
           <div className="flex w-29.25 flex-col items-center px-2.5 py-0.75 pb-1.5">
@@ -72,7 +78,7 @@ export default function CalendarHeader({
               합계
             </p>
             <p className="whitespace-nowrap text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#030303]">
-              100,000원
+              {balance.toLocaleString()}원
             </p>
           </div>
         </div>

--- a/src/features/calendar/ui/DateBottomSheet.tsx
+++ b/src/features/calendar/ui/DateBottomSheet.tsx
@@ -7,6 +7,7 @@ interface ExpenseItem {
   tags: string[];
   amount: number;
   paymentMethod: string;
+  memo?: string;
 }
 
 interface DayDetailSheetProps {
@@ -50,6 +51,7 @@ export default function DateBottomSheet({
     new Date(year, month, date).getDay()
   ];
   const dateLabel = `${month + 1}월 ${date}일 (${dayOfWeek})`;
+  const isEmpty = expenseItems.length === 0 && income === 0 && expense === 0;
 
   return (
     <div
@@ -57,14 +59,15 @@ export default function DateBottomSheet({
       onClick={handleClose}
     >
       <div
-        className={`absolute inset-0 bg-black/40 transition-opacity duration-300 ${isClosing ? 'opacity-0' : 'opacity-100'}`}
+        className={`absolute inset-0 bg-black/30 transition-opacity duration-300 ${isClosing ? 'opacity-0' : 'opacity-100'}`}
       />
 
       <div
-        className={`relative flex w-full max-w-md h-[calc(100dvh-89px)] flex-col rounded-t-[20px] bg-white px-4 py-10 transition-transform duration-300 ease-out ${isOpen && !isClosing ? 'translate-y-0' : 'translate-y-full'}`}
+        className={`relative flex w-full max-w-md flex-col rounded-t-[20px] bg-white px-4 pt-10 transition-transform duration-300 ease-out ${
+          isEmpty ? 'h-107.25' : 'max-h-[calc(100dvh-89px)] pb-10'
+        } ${isOpen && !isClosing ? 'translate-y-0' : 'translate-y-full'}`}
         onClick={(e) => e.stopPropagation()}
       >
-
         <div className="flex items-center justify-between">
           <p className="text-[18px] font-medium leading-normal tracking-[-0.45px] text-[#27282C]">
             {dateLabel}
@@ -74,59 +77,74 @@ export default function DateBottomSheet({
           </button>
         </div>
 
-        <div className="mt-5 flex flex-col gap-5 overflow-y-auto">
-
-          <div className="flex flex-col gap-1.25">
-            <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
-              수입
+        {isEmpty ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-0 pb-10">
+            <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#474C52]">
+              지출 기록이 아직 없어요
             </p>
-            <p className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#030303]">
-              {income.toLocaleString()}원
+            <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#9FA4A8]">
+              오늘의 소비와 감정을 함께 기록해보세요
             </p>
           </div>
-
-          <div className="flex flex-col gap-1.25">
-            <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
-              지출
-            </p>
-            <div className="flex items-center border-b border-[#E5E5E5] pb-3.75">
-              <p className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#EB1C1C]">
-                {expense.toLocaleString()}원
+        ) : (
+          <div className="mt-5 flex flex-col gap-5 overflow-y-auto">
+            <div className="flex flex-col gap-1.25">
+              <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
+                수입
+              </p>
+              <p className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#030303]">
+                {income.toLocaleString()}원
               </p>
             </div>
-          </div>
 
-          {/* 지출 항목 리스트 */}
-          <div className="flex flex-col gap-5">
-            {expenseItems.map((item, index) => (
-              <div key={index} className="flex flex-col gap-1.25">
-                <div className="flex items-center justify-between">
-                  <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
-                    {item.category}
-                  </p>
-                  <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
-                    {item.amount.toLocaleString()}원
-                  </p>
-                </div>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-1.5">
-                    {item.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#13278A]"
-                      >
-                        #{tag}
-                      </span>
-                    ))}
-                  </div>
-                  <p className="text-[12px] font-medium leading-normal tracking-[-0.3px] text-[#9FA4A8]">
-                    {item.paymentMethod}
-                  </p>
-                </div>
+            <div className="flex flex-col gap-1.25">
+              <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
+                지출
+              </p>
+              <div className="flex items-center border-b border-[#E5E5E5] pb-3.75">
+                <p className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#EB1C1C]">
+                  {expense.toLocaleString()}원
+                </p>
               </div>
-            ))}
+            </div>
+
+            {/* 지출 항목 리스트 */}
+            <div className="flex flex-col gap-5">
+              {expenseItems.map((item, index) => (
+                <div key={index} className="flex flex-col gap-0.75">
+                  <div className="flex items-center justify-between">
+                    <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
+                      {item.category}
+                    </p>
+                    <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
+                      {item.amount.toLocaleString()}원
+                    </p>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-1.5">
+                      {item.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#13278A]"
+                        >
+                          #{tag}
+                        </span>
+                      ))}
+                    </div>
+                    <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+                      {item.paymentMethod}
+                    </p>
+                  </div>
+                  {item.memo && (
+                    <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+                      {item.memo}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/src/widgets/record/RecordContent.tsx
+++ b/src/widgets/record/RecordContent.tsx
@@ -103,11 +103,13 @@ export default function RecordContent() {
 
   const today = '2026-04-22';
   const selectedDate = searchParams?.get('date') || today;
-  const isAssetMode = searchParams?.get('type') === 'asset';
+  const typeParam = searchParams?.get('type');
+  const isAssetMode = typeParam === 'asset';
+  const initialType: 'income' | 'expense' = typeParam === 'expense' ? 'expense' : 'income';
 
   const [record, setRecord] = useState<RecordState>({
     amount: 0,
-    type: 'income',
+    type: initialType,
     date: selectedDate,
     category: '',
     paymentMethod: '',


### PR DESCRIPTION
## 작업 내용         
                                                                                                   
  캘린더 페이지 디자인 수정 반영 및 화면 이동 처리                                                          
   
  ## 보완 항목                                                                                         
                  
  ### 디자인 반영                                                                                      
  - 날짜 셀에 수입/지출 금액 표시                                                        
  - 헤더 수입·지출·합계를 mock 데이터에서 자동 합산                                                    
  - 날짜 선택 시 오늘은 회색, 선택일은 남색으로 전환                                                   
  - 플로팅 버튼 위치 Figma 스펙 반영                                               
                                                                                                       
  ### 바텀시트                                                                                         
  - 빈 상태 분기                                                                                
  - 지출 항목에 메모 추가                                                                      
                                                                                                       
  ### 화면 이동   
  - 뒤로가기 버튼 → 메인 페이지(`/`) 이동                                                              
  - 플로팅 + 버튼 → 지출 추가 페이지(`/record?type=expense`) 이동                                      
  - `RecordContent`에서 `?type=expense` 쿼리 진입 시 지출 탭 활성화 상태로 시작                        
                                                                                                       
  ## 파일 구조                                                                                         
                                                                                                       
  ### src/features/calendar/mock/                                                                      
  - calendarMockData.ts: mock 데이터                                                    
                  
  ### src/features/calendar/ui/                                                                        
  - CalendarGrid.tsx: `dailyAmounts`, `selectedDay` prop 추가
  - CalendarHeader.tsx: 합계 props로 받음                                                              
  - DateBottomSheet.tsx: 빈 상태 분기 + 메모 표시                                        
                                                                                                       
  ### src/app/calendar/                                                                                
  - page.tsx: 라우팅 추가                                                           
                                                                                                       
  ### src/widgets/record/
  - RecordContent.tsx: `?type=expense` 쿼리 처리                                                       
                                                                                                       
  ## 참고
                                                                                                       
  - mock 데이터는 백엔드 API 연동 시 교체 예정                                                         
  - 감정 이모지 SVG로 교체 예정