### PR TITLE
[FIX] 회고 페이지 UI 보완 및 라우팅 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -147,6 +147,17 @@ html {
 .animate-fade-in {
   animation: fadeIn 0.3s ease-out;
 }
+
+/* 입력 검증 실패 시 쉐이크 애니메이션 */
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  15%, 45%, 75% { transform: translateX(-4px); }
+  30%, 60%, 90% { transform: translateX(4px); }
+}
+
+.animate-shake {
+  animation: shake 0.4s ease-in-out;
+}
 .dark {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);

--- a/src/app/retro/page.tsx
+++ b/src/app/retro/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import RetroEmpty from '@/features/retro/ui/RetroEmpty';
@@ -12,46 +11,32 @@ const TODAY_LABEL = `${TODAY.getMonth() + 1}월 ${TODAY.getDate()}일 지출`;
 
 export default function RetroPage() {
   const router = useRouter();
-  const [showTooltip, setShowTooltip] = useState(true);
 
-  const totalExpense = 0; // 임시: 지출 데이터 없음
+  const totalExpense = retroMockData.totalExpense;
   const hasData = totalExpense > 0;
 
   return (
     <div className="flex flex-1 flex-col">
       {/* 헤더 */}
-      <header className="flex h-14 items-center justify-between border-b border-gray-200 px-4">
-        <button onClick={() => router.back()}>
-          <Image src="/icons/icon_arrow_left.svg" alt="뒤로가기" width={28} height={28} />
+      <header className="flex h-14 items-center justify-between px-4">
+        <button onClick={() => router.push('/')} aria-label="메인으로 이동">
+          <Image src="/icons/icon_arrow_left.svg" alt="" width={28} height={28} />
         </button>
-        <h1 className="text-lg font-semibold">회고하기</h1>
+        <h1 className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
+          회고하기
+        </h1>
         <div className="w-7" />
       </header>
 
-      {/* 날짜 / 금액 */}
       <div className="px-4 pt-5">
-        <p className="mb-2 text-sm font-medium text-gray-500">{TODAY_LABEL}</p>
-        <div className="relative flex items-center gap-2">
-          <p className="text-[28px] font-bold">{totalExpense.toLocaleString()}원</p>
-          <button onClick={() => setShowTooltip(!showTooltip)}>
-            <Image src="/icons/icon_info.svg" alt="정보" width={28} height={28} />
-          </button>
-
-          {showTooltip && (
-            <div className="absolute top-1/2 left-40 z-10 flex -translate-y-1/2 items-start gap-2.5 rounded-lg bg-white p-2.5 shadow-sm">
-              <p className="max-w-[165px] text-xs font-medium text-gray-500">
-                가계부를 더 자세히 기록할수록, 회고가 더 정확해져요
-              </p>
-              <button onClick={() => setShowTooltip(false)}>
-                <Image src="/icons/icon_X.svg" alt="닫기" width={12} height={12} />
-              </button>
-              <div className="absolute top-4 -left-1.5 h-3 w-3 rotate-45 bg-white shadow-sm" />
-            </div>
-          )}
-        </div>
+        <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#73787E]">
+          {TODAY_LABEL}
+        </p>
+        <p className="text-[28px] font-semibold leading-normal tracking-[-0.7px] text-[#030303]">
+          {totalExpense.toLocaleString()}원
+        </p>
       </div>
 
-      {/* 콘텐츠 영역 */}
       <div className="flex flex-1 items-start justify-center px-4 pt-7">
         {hasData ? (
           <RetroMain
@@ -66,11 +51,10 @@ export default function RetroPage() {
         )}
       </div>
 
-      {/* 하단 버튼 */}
-      <div className="flex w-full items-center justify-center bg-white px-4 pt-6 pb-24">
+      <div className="flex w-full items-center justify-center bg-white px-4 pt-6 pb-12.75">
         <button
-          onClick={() => router.push(hasData ? '/retro/survey' : '/calendar')}
-          className="h-14 w-full rounded-lg bg-blue-900 text-base font-semibold text-white transition-colors hover:bg-blue-800"
+          onClick={() => router.push(hasData ? '/retro/survey' : '/record?type=expense')}
+          className="h-13.5 w-full rounded-[10px] bg-[#13278A] text-[20px] font-semibold leading-normal tracking-[-0.5px] text-white transition-colors hover:bg-[#0F1F6E]"
         >
           {hasData ? '소비 회고하기' : '소비 기록하러 가기'}
         </button>

--- a/src/app/retro/survey/page.tsx
+++ b/src/app/retro/survey/page.tsx
@@ -40,6 +40,7 @@ export default function RetroSurveyPage() {
   const [selectedSatisfaction, setSelectedSatisfaction] = useState<string | null>(null);
   const [selectedPlan, setSelectedPlan] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
+  const [shakeKey, setShakeKey] = useState(0);
 
   const isAllSelected =
     selectedEmotion && selectedSituation && selectedSatisfaction && selectedPlan;
@@ -47,6 +48,7 @@ export default function RetroSurveyPage() {
   const handleSubmit = () => {
     if (!isAllSelected) {
       setSubmitted(true);
+      setShakeKey((prev) => prev + 1);
       return;
     }
     router.push('/retro/result');
@@ -77,7 +79,10 @@ export default function RetroSurveyPage() {
               오늘 소비를 이끈 감정은 무엇이였나요?
             </p>
             {submitted && !selectedEmotion && (
-              <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#EB1C1C]">
+              <p
+                key={shakeKey}
+                className="animate-shake text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#EB1C1C]"
+              >
                 항목을 선택해주세요
               </p>
             )}
@@ -96,7 +101,10 @@ export default function RetroSurveyPage() {
               어떤 상황에서 소비하게 됐나요?
             </p>
             {submitted && !selectedSituation && (
-              <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#EB1C1C]">
+              <p
+                key={shakeKey}
+                className="animate-shake text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#EB1C1C]"
+              >
                 항목을 선택해주세요
               </p>
             )}
@@ -115,7 +123,10 @@ export default function RetroSurveyPage() {
               소비가 전반적으로 만족스러웠나요?
             </p>
             {submitted && !selectedSatisfaction && (
-              <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#EB1C1C]">
+              <p
+                key={shakeKey}
+                className="animate-shake text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#EB1C1C]"
+              >
                 항목을 선택해주세요
               </p>
             )}
@@ -134,7 +145,10 @@ export default function RetroSurveyPage() {
               내일은 어떻게 소비하고 싶나요?
             </p>
             {submitted && !selectedPlan && (
-              <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#EB1C1C]">
+              <p
+                key={shakeKey}
+                className="animate-shake text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#EB1C1C]"
+              >
                 항목을 선택해주세요
               </p>
             )}

--- a/src/features/retro/ui/RetroEmpty.tsx
+++ b/src/features/retro/ui/RetroEmpty.tsx
@@ -1,12 +1,12 @@
 export default function RetroEmpty() {
   return (
-    <div className="flex w-89.5 h-90 items-center justify-center rounded-[10px] bg-[#F7F8FA] p-2.5">
-      <div className="flex flex-col items-center gap-2">
-        <p className="text-[16px] font-semibold text-[#1C1D1F]">
-          오늘의 소비가 아직 없어요
+    <div className="flex h-90 w-89.5 items-center justify-center rounded-[12px] bg-[#F7F8FA] p-2.5">
+      <div className="flex flex-col items-center">
+        <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#474C52]">
+          지출 기록이 아직 없어요
         </p>
-        <p className="text-[13px] font-medium text-[#AEAEAE]">
-          소비를 기록하면 오늘을 돌아볼 수 있어요
+        <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#9FA4A8]">
+          오늘의 소비를 기록하고 하루를 돌아보세요
         </p>
       </div>
     </div>

--- a/src/features/retro/ui/RetroMain.tsx
+++ b/src/features/retro/ui/RetroMain.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
 interface ExpenseCategory {
   name: string;
   amount: number;
@@ -23,12 +27,19 @@ export default function RetroMain({
   categories,
   emotions,
 }: RetroMainProps) {
+  const router = useRouter();
   const maxAmount = Math.max(...categories.map((c) => c.amount));
+
+  const handleDetailClick = () => {
+    const today = new Date();
+    const dateString = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+    router.push(`/export?date=${dateString}`);
+  };
 
   return (
     <div className="flex w-full flex-col gap-4">
 
-      <div className="relative flex h-90 w-89.5 flex-col items-center rounded-[10px] bg-[#F7F8FA]">
+      <div className="relative flex h-90 w-89.5 flex-col items-center rounded-[12px] bg-[#F7F8FA]">
         <div className="mt-7.5 flex flex-col items-center gap-0.5">
           <p className="text-[18px] font-bold text-[#1C1D1F]">
             오늘은 {topCategory}에 가장 많이 지출했어요
@@ -50,25 +61,28 @@ export default function RetroMain({
                   cat.name === topCategory ? 'bg-[#6B9CE5]' : 'bg-[#CACDD2]'
                 }`}
                 style={{
-                  height: `${Math.max((cat.amount / maxAmount) * 140, 20)}px`,
+                  height: `${Math.max((cat.amount / maxAmount) * 140, 40)}px`,
                 }}
               />
             </div>
           ))}
         </div>
 
-        <button className="absolute bottom-4 mx-auto w-78.5 rounded-lg bg-[#DEE8F7] px-14 py-2.5">
+        <button
+          onClick={handleDetailClick}
+          className="absolute bottom-4 mx-auto w-78.5 rounded-lg bg-[#DEE8F7] px-14 py-2.5"
+        >
           <p className="text-center text-[16px] font-semibold text-[#13278A]">
             지출 상세 내역
           </p>
         </button>
       </div>
 
-      <div className="flex gap-2 overflow-x-auto">
+      <div className="flex gap-1.5 overflow-x-auto">
         {emotions.map((emotion) => (
           <div
             key={emotion.name}
-            className="flex h-21.25 w-37 shrink-0 flex-col items-center justify-center rounded-[10px] bg-[#F7F8FA] px-4 py-3.5"
+            className="flex h-21.25 w-37 shrink-0 flex-col items-center justify-center rounded-[12px] bg-[#F7F8FA] px-4 py-3.5"
           >
             <p className="text-[14px] font-medium text-[#73787E]">
               오늘의 소비 감정


### PR DESCRIPTION
## 작업 내용                                                                                         
                                                                                                       
  회고 페이지 디자인 반영 및 화면 이동 처리                                                            
                                                                                                       
  ## 보완 항목                                                                                         
                                                                                                       
  ### 디자인                                                                                           
  - 툴팁 제거                                                   
  - 빈 상태 멘트 변경
  - 빈 상태 카드·메인 카드·감정 카드 라운드 12px로 통일                                                            
  - 감정 카드 사이 간격 6px                                                                            
                                                                                                       
  ### 데이터 연동                                                                                      
  - 하드코딩된 `totalExpense = 0` → mock 데이터(`retroMockData.totalExpense`) 적용                     
                                                                                                       
  ### 화면 이동                                                                                        
  - 뒤로가기 → 메인 페이지(`/`)
  - 빈 상태 "소비 기록하러 가기" → 지출 추가 페이지(`/record?type=expense`)                            
  - "지출 상세 내역" → 오늘의 지출 페이지(`/export?date=오늘`)
                                                                                                       
  ### 인터랙션                                                                                         
  - 설문 페이지에서 미선택 항목 안내 문구에 쉐이크 애니메이션 추가                                     
                                                                                                       
  ## 파일 구조                                                                                         
                                                                                                       
  ### src/app/retro/                                                                                   
  - page.tsx: 툴팁 제거 + mock 연동 + 라우팅 추가
  - survey/page.tsx: 안내 문구 쉐이크 애니메이션 적용                                                  
                                                                                                       
  ### src/features/retro/ui/                  
  - RetroEmpty.tsx: 멘트·스타일 Figma 반영                                                             
  - RetroMain.tsx: 라운드·간격 조정 + 라우팅 추가
                                                                                                       
  ### src/app/globals.css                 
  - `@keyframes shake` + `.animate-shake` 추가                                                         
                                                                                                       
  ## 참고                                                                                              
  - mock 데이터는 백엔드 API 연동 시 교체 예정