### PR TITLE
[FIX] 리포트 페이지 디자인 수정사항 반영

### DIFF
--- a/src/app/report/category/[categoryId]/page.tsx
+++ b/src/app/report/category/[categoryId]/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { use, useMemo, useState } from 'react';
-import Image from 'next/image';
 import PageHeader from '@/shared/ui/PageHeader';
 import SortButton, { type SortType } from '@/shared/ui/SortButton';
+import EmotionIcon from '@/shared/ui/EmotionIcon';
 import {
   getCategoryDetail,
   type ExpenseItem,
@@ -14,20 +14,6 @@ import {
 interface PageProps {
   params: Promise<{ categoryId: string }>;
 }
-
-const EMOTION_NAME_TO_SVG: Record<string, string> = {
-  심심함: 'boring',
-  공허함: 'emptiness',
-  피곤함: 'tired',
-  기쁨: 'happy',
-  설렘: 'flut',
-  고마움: 'thanks',
-  충동: 'impulse',
-  불안함: 'anxios',
-  뿌듯함: 'proud',
-  우울함: 'depressed',
-  슬픔: 'sad',
-};
 
 interface FlatItem extends ExpenseItem {
   dateLabel: string;
@@ -100,25 +86,9 @@ function ExpenseItemRow({ item, showDate }: { item: FlatItem; showDate: boolean 
             <>
               <span className="h-3.5 w-px bg-[#D9D9D9]" />
               <div className="flex items-center gap-1.5">
-                {item.emotions.map((emo: EmotionBadge) => {
-                  const svgKey = EMOTION_NAME_TO_SVG[emo.name];
-                  if (!svgKey) {
-                    return (
-                      <span key={emo.name} className="text-[18px] leading-none">
-                        {emo.emoji}
-                      </span>
-                    );
-                  }
-                  return (
-                    <Image
-                      key={emo.name}
-                      src={`/svg/emo/${svgKey}.svg`}
-                      alt={emo.name}
-                      width={20}
-                      height={20}
-                    />
-                  );
-                })}
+                {item.emotions.map((emo: EmotionBadge) => (
+                  <EmotionIcon key={emo.name} name={emo.name} size={20} />
+                ))}
               </div>
             </>
           )}

--- a/src/app/report/category/[categoryId]/page.tsx
+++ b/src/app/report/category/[categoryId]/page.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import { use, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { use, useMemo, useState } from 'react';
+import Image from 'next/image';
+import PageHeader from '@/shared/ui/PageHeader';
+import SortButton, { type SortType } from '@/shared/ui/SortButton';
 import {
   getCategoryDetail,
+  type ExpenseItem,
+  type ExpenseDateGroup,
   type EmotionBadge,
 } from '@/features/report/mock/categoryDetailMockData';
 
@@ -11,175 +15,194 @@ interface PageProps {
   params: Promise<{ categoryId: string }>;
 }
 
-export default function CategoryDetailPage({ params }: PageProps) {
-  const router = useRouter();
-  const { categoryId } = use(params);
-  const decodedId = decodeURIComponent(categoryId);
-  const detail = getCategoryDetail(decodedId);
+const EMOTION_NAME_TO_SVG: Record<string, string> = {
+  심심함: 'boring',
+  공허함: 'emptiness',
+  피곤함: 'tired',
+  기쁨: 'happy',
+  설렘: 'flut',
+  고마움: 'thanks',
+  충동: 'impulse',
+  불안함: 'anxios',
+  뿌듯함: 'proud',
+  우울함: 'depressed',
+  슬픔: 'sad',
+};
 
-  const today = new Date();
-  const currentYear = today.getFullYear();
-  const currentMonth = today.getMonth() + 1;
+interface FlatItem extends ExpenseItem {
+  dateLabel: string;
+  dateOrder: number;
+}
 
-  const [year, setYear] = useState(currentYear);
-  const [month, setMonth] = useState(detail?.month ?? currentMonth);
+function flattenGroups(month: number, groups: ExpenseDateGroup[]): FlatItem[] {
+  return groups.flatMap((g) =>
+    g.items.map((item) => ({
+      ...item,
+      dateLabel: `${month}월 ${g.date}`,
+      dateOrder: parseInt(g.date.replace(/[^0-9]/g, ''), 10),
+    })),
+  );
+}
 
-  const isNextDisabled = year > currentYear || (year === currentYear && month >= currentMonth);
-  const monthLabel = year === currentYear ? `${month}월` : `${year}년 ${month}월`;
-
-  const handlePrev = () => {
-    if (month === 1) {
-      setYear((y) => y - 1);
-      setMonth(12);
-    } else {
-      setMonth((m) => m - 1);
-    }
-  };
-
-  const handleNext = () => {
-    if (isNextDisabled) return;
-    if (month === 12) {
-      setYear((y) => y + 1);
-      setMonth(1);
-    } else {
-      setMonth((m) => m + 1);
-    }
-  };
-
-  if (!detail) {
-    return (
-      <div className="flex flex-1 flex-col items-center justify-center bg-white px-6">
-        <p className="text-[16px] text-[#73787E]">카테고리를 찾을 수 없어요.</p>
-        <button
-          onClick={() => router.back()}
-          className="mt-4 rounded-lg border border-[#E5E5E5] px-4 py-2 text-[14px]"
-        >
-          돌아가기
-        </button>
-      </div>
-    );
+function sortFlatItems(items: FlatItem[], sortType: SortType): FlatItem[] {
+  const sorted = [...items];
+  switch (sortType) {
+    case 'latest':
+      return sorted.sort((a, b) => b.dateOrder - a.dateOrder);
+    case 'oldest':
+      return sorted.sort((a, b) => a.dateOrder - b.dateOrder);
+    case 'expensive':
+      return sorted.sort((a, b) => b.amount - a.amount);
+    case 'cheap':
+      return sorted.sort((a, b) => a.amount - b.amount);
+    default:
+      return sorted;
   }
+}
 
+interface DayGroup {
+  dateLabel: string;
+  items: FlatItem[];
+}
+
+function regroupByDate(items: FlatItem[]): DayGroup[] {
+  const map = new Map<string, DayGroup>();
+  items.forEach((item) => {
+    if (!map.has(item.dateLabel)) {
+      map.set(item.dateLabel, { dateLabel: item.dateLabel, items: [] });
+    }
+    map.get(item.dateLabel)!.items.push(item);
+  });
+  return Array.from(map.values());
+}
+
+function ExpenseItemRow({ item, showDate }: { item: FlatItem; showDate: boolean }) {
   return (
-    <div className="flex flex-1 flex-col bg-white">
-      {/* 헤더 */}
-      <header className="flex flex-col gap-4.5 border-b-[5px] border-[#F7F8FA] px-4 pt-3 pb-5">
-        <button onClick={() => router.back()} aria-label="뒤로가기">
-          <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
-            <path
-              d="M18 6L10 14L18 22"
-              stroke="#27282C"
-              strokeWidth="1.87"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </button>
-
-        <div className="flex items-center gap-2.5">
-          <button onClick={handlePrev} aria-label="이전 달">
-            <img
-              src="/icons/icon_arrow_left_fill.svg"
-              alt=""
-              width={26}
-              height={26}
-            />
-          </button>
-          <span
-            className={`text-center text-[22px] font-bold leading-normal tracking-[-0.55px] text-[#27282C] ${
-              year === currentYear ? 'w-13.5' : ''
-            }`}
-          >
-            {monthLabel}
-          </span>
-          <button onClick={handleNext} disabled={isNextDisabled} aria-label="다음 달">
-            <img
-              src="/icons/icon_arrow_right_fill.svg"
-              alt=""
-              width={26}
-              height={26}
-              className={isNextDisabled ? 'opacity-30' : 'opacity-100'}
-            />
-          </button>
-        </div>
-
-        <div className="flex items-center gap-3">
-          <span className="flex h-18 w-12 items-center justify-center text-[48px] leading-none">
-            {detail.emoji}
-          </span>
-          <div className="flex flex-col gap-0.5">
-            <span className="text-[18px] font-medium tracking-[-0.45px] text-[#474C52]">
-              {detail.name}
-            </span>
-            <span className="text-[28px] font-semibold tracking-[-0.7px] text-[#030303]">
-              {detail.totalAmount.toLocaleString()}원
-            </span>
-          </div>
-        </div>
-      </header>
-
-      <div className="flex flex-col pb-30">
-        {detail.groups.map((group, groupIdx) => (
-          <section
-            key={groupIdx}
-            className="flex flex-col gap-3.75 border-b border-[#E5E5E5] py-7.5"
-          >
-            {group.items.map((item, itemIdx) => (
-              <article key={item.id} className="flex flex-col gap-0.75 px-4">
-                {itemIdx === 0 && (
-                  <span className="text-[14px] font-medium tracking-[-0.35px] text-[#73787E]">
-                    {group.date}
-                  </span>
-                )}
-
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <div className="flex items-center gap-1.5">
-                      {item.tags.map((tag, i) => (
-                        <span
-                          key={i}
-                          className="text-[16px] font-medium tracking-[-0.4px] text-[#13278A]"
-                        >
-                          #{tag}
-                        </span>
-                      ))}
-                    </div>
-                    <span className="h-3.5 w-px bg-[#D9D9D9]" />
-                    <div className="flex items-center gap-1.5">
-                      {item.emotions.map((emo, i) => (
-                        <EmotionDot key={i} emotion={emo} />
-                      ))}
-                    </div>
-                  </div>
-                  <span className="text-[20px] font-semibold tracking-[-0.5px] text-[#030303]">
-                    {item.amount.toLocaleString()}원
-                  </span>
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <span className="text-[16px] font-medium tracking-[-0.4px] text-[#9FA4A8]">
-                    {item.memo ?? ''}
-                  </span>
-                  <span className="text-[16px] font-medium tracking-[-0.4px] text-[#9FA4A8]">
-                    {item.payment}
-                  </span>
-                </div>
-              </article>
+    <div className="flex flex-col gap-1.25">
+      {showDate && (
+        <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#73787E]">
+          {item.dateLabel}
+        </p>
+      )}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
+            {item.tags.map((tag) => (
+              <span
+                key={tag}
+                className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#13278A]"
+              >
+                #{tag}
+              </span>
             ))}
-          </section>
-        ))}
+          </div>
+          {item.emotions.length > 0 && (
+            <>
+              <span className="h-3.5 w-px bg-[#D9D9D9]" />
+              <div className="flex items-center gap-1.5">
+                {item.emotions.map((emo: EmotionBadge) => {
+                  const svgKey = EMOTION_NAME_TO_SVG[emo.name];
+                  if (!svgKey) {
+                    return (
+                      <span key={emo.name} className="text-[18px] leading-none">
+                        {emo.emoji}
+                      </span>
+                    );
+                  }
+                  return (
+                    <Image
+                      key={emo.name}
+                      src={`/svg/emo/${svgKey}.svg`}
+                      alt={emo.name}
+                      width={20}
+                      height={20}
+                    />
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </div>
+        <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
+          {item.amount.toLocaleString()}원
+        </p>
+      </div>
+      <div className="flex items-center justify-between">
+        <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+          {item.memo ?? ''}
+        </p>
+        <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+          {item.payment}
+        </p>
       </div>
     </div>
   );
 }
 
-function EmotionDot({ emotion }: { emotion: EmotionBadge }) {
+export default function CategoryDetailPage({ params }: PageProps) {
+  const { categoryId } = use(params);
+  const decodedId = decodeURIComponent(categoryId);
+  const detail = getCategoryDetail(decodedId)!;
+  const [sortType, setSortType] = useState<SortType>('latest');
+
+  const flatItems = useMemo(
+    () => flattenGroups(detail.month, detail.groups),
+    [detail],
+  );
+  const sortedItems = useMemo(() => sortFlatItems(flatItems, sortType), [flatItems, sortType]);
+  const groupedItems = useMemo(() => regroupByDate(sortedItems), [sortedItems]);
+
+  const isDateSort = sortType === 'latest' || sortType === 'oldest';
+
   return (
-    <span
-      className="flex size-5 items-center justify-center text-[18px] leading-none"
-      aria-label={emotion.name}
-    >
-      {emotion.emoji}
-    </span>
+    <div className="flex flex-1 flex-col bg-white">
+      <PageHeader title="카테고리별 지출 항목" />
+
+      <div className="border-b-[5px] border-[#F7F8FA] px-4 pt-3 pb-5">
+        <div className="flex items-center gap-4">
+          <span className="flex h-18 w-12 items-center justify-center text-[48px] leading-[150%]">
+            {detail.emoji}
+          </span>
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[18px] font-medium leading-normal tracking-[-0.45px] text-[#474C52]">
+              {detail.name}
+            </span>
+            <span className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#030303]">
+              {detail.totalAmount.toLocaleString()}원
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-end px-4 pt-4">
+        <SortButton sortType={sortType} onSortChange={setSortType} />
+      </div>
+
+      {isDateSort ? (
+        <div className="flex flex-col">
+          {groupedItems.map((group) => (
+            <div
+              key={group.dateLabel}
+              className="flex flex-col gap-3.75 border-b border-[#E5E5E5] px-4 py-7.5 last:border-b-0"
+            >
+              <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#73787E]">
+                {group.dateLabel}
+              </p>
+              <div className="flex flex-col gap-5">
+                {group.items.map((item) => (
+                  <ExpenseItemRow key={item.id} item={item} showDate={false} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-7.5 px-4 pt-3.75 pb-7.5">
+          {sortedItems.map((item) => (
+            <ExpenseItemRow key={item.id} item={item} showDate={true} />
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/app/report/emotion/[emotionId]/page.tsx
+++ b/src/app/report/emotion/[emotionId]/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { use, useMemo, useState } from 'react';
-import Image from 'next/image';
 import PageHeader from '@/shared/ui/PageHeader';
 import SortButton, { type SortType } from '@/shared/ui/SortButton';
+import EmotionIcon from '@/shared/ui/EmotionIcon';
 import {
   getEmotionDetail,
   type EmotionExpenseItem,
@@ -13,22 +13,6 @@ import {
 interface PageProps {
   params: Promise<{ emotionId: string }>;
 }
-
-const EMOTION_NAME_TO_SVG: Record<string, string> = {
-  심심함: 'boring',
-  공허함: 'emptiness',
-  피곤함: 'tired',
-  기쁨: 'happy',
-  설렘: 'flut',
-  고마움: 'thanks',
-  충동: 'impulse',
-  불안함: 'anxios',
-  뿌듯함: 'proud',
-  우울함: 'depressed',
-  슬픔: 'sad',
-  스트레스: 'stress',
-  외로움: 'lonely',
-};
 
 interface FlatItem extends EmotionExpenseItem {
   dateLabel: string;
@@ -131,7 +115,6 @@ export default function EmotionDetailPage({ params }: PageProps) {
   const groupedItems = useMemo(() => regroupByDate(sortedItems), [sortedItems]);
 
   const isDateSort = sortType === 'latest' || sortType === 'oldest';
-  const svgKey = EMOTION_NAME_TO_SVG[detail.name];
 
   return (
     <div className="flex flex-1 flex-col bg-white">
@@ -139,18 +122,7 @@ export default function EmotionDetailPage({ params }: PageProps) {
 
       <div className="border-b-[5px] border-[#F7F8FA] px-4 pt-3 pb-5">
         <div className="flex items-center gap-4">
-          {svgKey ? (
-            <Image
-              src={`/svg/emo/${svgKey}.svg`}
-              alt={detail.name}
-              width={48}
-              height={48}
-            />
-          ) : (
-            <span className="flex size-12 items-center justify-center text-[40px] leading-none">
-              {detail.emoji}
-            </span>
-          )}
+          <EmotionIcon name={detail.name} size={48} />
           <div className="flex flex-col gap-0.5">
             <span className="text-[18px] font-medium leading-normal tracking-[-0.45px] text-[#474C52]">
               {detail.name}

--- a/src/app/report/emotion/[emotionId]/page.tsx
+++ b/src/app/report/emotion/[emotionId]/page.tsx
@@ -1,164 +1,196 @@
 'use client';
 
-import { use, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { getEmotionDetail } from '@/features/report/mock/emotionDetailMockData';
+import { use, useMemo, useState } from 'react';
+import Image from 'next/image';
+import PageHeader from '@/shared/ui/PageHeader';
+import SortButton, { type SortType } from '@/shared/ui/SortButton';
+import {
+  getEmotionDetail,
+  type EmotionExpenseItem,
+  type EmotionExpenseDateGroup,
+} from '@/features/report/mock/emotionDetailMockData';
 
 interface PageProps {
   params: Promise<{ emotionId: string }>;
 }
 
+const EMOTION_NAME_TO_SVG: Record<string, string> = {
+  심심함: 'boring',
+  공허함: 'emptiness',
+  피곤함: 'tired',
+  기쁨: 'happy',
+  설렘: 'flut',
+  고마움: 'thanks',
+  충동: 'impulse',
+  불안함: 'anxios',
+  뿌듯함: 'proud',
+  우울함: 'depressed',
+  슬픔: 'sad',
+  스트레스: 'stress',
+  외로움: 'lonely',
+};
+
+interface FlatItem extends EmotionExpenseItem {
+  dateLabel: string;
+  dateOrder: number;
+}
+
+function flattenGroups(month: number, groups: EmotionExpenseDateGroup[]): FlatItem[] {
+  return groups.flatMap((g) =>
+    g.items.map((item) => ({
+      ...item,
+      dateLabel: `${month}월 ${g.date}`,
+      dateOrder: parseInt(g.date.replace(/[^0-9]/g, ''), 10),
+    })),
+  );
+}
+
+function sortFlatItems(items: FlatItem[], sortType: SortType): FlatItem[] {
+  const sorted = [...items];
+  switch (sortType) {
+    case 'latest':
+      return sorted.sort((a, b) => b.dateOrder - a.dateOrder);
+    case 'oldest':
+      return sorted.sort((a, b) => a.dateOrder - b.dateOrder);
+    case 'expensive':
+      return sorted.sort((a, b) => b.amount - a.amount);
+    case 'cheap':
+      return sorted.sort((a, b) => a.amount - b.amount);
+    default:
+      return sorted;
+  }
+}
+
+interface DayGroup {
+  dateLabel: string;
+  items: FlatItem[];
+}
+
+function regroupByDate(items: FlatItem[]): DayGroup[] {
+  const map = new Map<string, DayGroup>();
+  items.forEach((item) => {
+    if (!map.has(item.dateLabel)) {
+      map.set(item.dateLabel, { dateLabel: item.dateLabel, items: [] });
+    }
+    map.get(item.dateLabel)!.items.push(item);
+  });
+  return Array.from(map.values());
+}
+
+function ExpenseItemRow({ item, showDate }: { item: FlatItem; showDate: boolean }) {
+  return (
+    <div className="flex flex-col gap-1.25">
+      {showDate && (
+        <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#73787E]">
+          {item.dateLabel}
+        </p>
+      )}
+      <div className="flex items-center justify-between">
+        <span className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
+          {item.category}
+        </span>
+        <span className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
+          {item.amount.toLocaleString()}원
+        </span>
+      </div>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          {item.tags.map((tag) => (
+            <span
+              key={tag}
+              className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#13278A]"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+        <span className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+          {item.payment}
+        </span>
+      </div>
+      {item.memo && (
+        <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+          {item.memo}
+        </p>
+      )}
+    </div>
+  );
+}
+
 export default function EmotionDetailPage({ params }: PageProps) {
-  const router = useRouter();
   const { emotionId } = use(params);
   const decodedId = decodeURIComponent(emotionId);
-  const detail = getEmotionDetail(decodedId);
+  const detail = getEmotionDetail(decodedId)!;
+  const [sortType, setSortType] = useState<SortType>('latest');
 
-  const today = new Date();
-  const currentYear = today.getFullYear();
-  const currentMonth = today.getMonth() + 1;
+  const flatItems = useMemo(
+    () => flattenGroups(detail.month, detail.groups),
+    [detail],
+  );
+  const sortedItems = useMemo(() => sortFlatItems(flatItems, sortType), [flatItems, sortType]);
+  const groupedItems = useMemo(() => regroupByDate(sortedItems), [sortedItems]);
 
-  const [year, setYear] = useState(currentYear);
-  const [month, setMonth] = useState(detail?.month ?? currentMonth);
-
-  const isNextDisabled = year > currentYear || (year === currentYear && month >= currentMonth);
-  const monthLabel = year === currentYear ? `${month}월` : `${year}년 ${month}월`;
-
-  const handlePrev = () => {
-    if (month === 1) {
-      setYear((y) => y - 1);
-      setMonth(12);
-    } else {
-      setMonth((m) => m - 1);
-    }
-  };
-
-  const handleNext = () => {
-    if (isNextDisabled) return;
-    if (month === 12) {
-      setYear((y) => y + 1);
-      setMonth(1);
-    } else {
-      setMonth((m) => m + 1);
-    }
-  };
-
-  if (!detail) {
-    return (
-      <div className="flex flex-1 flex-col items-center justify-center bg-white px-6">
-        <p className="text-[16px] text-[#73787E]">감정을 찾을 수 없어요.</p>
-        <button
-          onClick={() => router.back()}
-          className="mt-4 rounded-lg border border-[#E5E5E5] px-4 py-2 text-[14px]"
-        >
-          돌아가기
-        </button>
-      </div>
-    );
-  }
+  const isDateSort = sortType === 'latest' || sortType === 'oldest';
+  const svgKey = EMOTION_NAME_TO_SVG[detail.name];
 
   return (
     <div className="flex flex-1 flex-col bg-white">
-      {/* 헤더 */}
-      <header className="flex flex-col gap-4.5 border-b-[5px] border-[#F7F8FA] px-4 pt-3 pb-5">
-        <button onClick={() => router.back()} aria-label="뒤로가기">
-          <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
-            <path
-              d="M18 6L10 14L18 22"
-              stroke="#27282C"
-              strokeWidth="1.87"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </button>
+      <PageHeader title="감정별 지출 항목" />
 
-        <div className="flex items-center gap-2.5">
-          <button onClick={handlePrev} aria-label="이전 달">
-            <img
-              src="/icons/icon_arrow_left_fill.svg"
-              alt=""
-              width={26}
-              height={26}
+      <div className="border-b-[5px] border-[#F7F8FA] px-4 pt-3 pb-5">
+        <div className="flex items-center gap-4">
+          {svgKey ? (
+            <Image
+              src={`/svg/emo/${svgKey}.svg`}
+              alt={detail.name}
+              width={48}
+              height={48}
             />
-          </button>
-          <span
-            className={`text-center text-[22px] font-bold leading-normal tracking-[-0.55px] text-[#27282C] ${
-              year === currentYear ? 'w-13.5' : ''
-            }`}
-          >
-            {monthLabel}
-          </span>
-          <button onClick={handleNext} disabled={isNextDisabled} aria-label="다음 달">
-            <img
-              src="/icons/icon_arrow_right_fill.svg"
-              alt=""
-              width={26}
-              height={26}
-              className={isNextDisabled ? 'opacity-30' : 'opacity-100'}
-            />
-          </button>
-        </div>
-
-        <div className="flex items-center gap-3">
-          <span className="flex size-12 items-center justify-center text-[40px] leading-none">
-            {detail.emoji}
-          </span>
+          ) : (
+            <span className="flex size-12 items-center justify-center text-[40px] leading-none">
+              {detail.emoji}
+            </span>
+          )}
           <div className="flex flex-col gap-0.5">
-            <span className="text-[18px] font-medium tracking-[-0.45px] text-[#474C52]">
+            <span className="text-[18px] font-medium leading-normal tracking-[-0.45px] text-[#474C52]">
               {detail.name}
             </span>
-            <span className="text-[28px] font-semibold tracking-[-0.7px] text-[#030303]">
+            <span className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#030303]">
               {detail.totalAmount.toLocaleString()}원
             </span>
           </div>
         </div>
-      </header>
-
-      <div className="flex flex-col pb-30">
-        {detail.groups.map((group, groupIdx) => (
-          <section
-            key={groupIdx}
-            className="flex flex-col gap-7.5 border-b border-[#E5E5E5] py-7.5"
-          >
-            {group.items.map((item) => (
-              <article key={item.id} className="flex flex-col gap-0.75 px-4">
-                <span className="text-[14px] font-medium tracking-[-0.35px] text-[#73787E]">
-                  {group.date}
-                </span>
-                <div className="flex items-center justify-between">
-                  <span className="text-[18px] font-semibold tracking-[-0.45px] text-[#27282C]">
-                    {item.category}
-                  </span>
-                  <span className="text-[20px] font-semibold tracking-[-0.5px] text-[#030303]">
-                    {item.amount.toLocaleString()}원
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-1.5">
-                    {item.tags.map((tag, i) => (
-                      <span
-                        key={i}
-                        className="text-[16px] font-medium tracking-[-0.4px] text-[#13278A]"
-                      >
-                        #{tag}
-                      </span>
-                    ))}
-                  </div>
-                  <span className="text-[16px] font-medium tracking-[-0.4px] text-[#9FA4A8]">
-                    {item.payment}
-                  </span>
-                </div>
-                {item.memo && (
-                  <span className="text-[16px] font-medium tracking-[-0.4px] text-[#9FA4A8]">
-                    {item.memo}
-                  </span>
-                )}
-              </article>
-            ))}
-          </section>
-        ))}
       </div>
+
+      <div className="flex justify-end px-4 pt-4">
+        <SortButton sortType={sortType} onSortChange={setSortType} />
+      </div>
+
+      {isDateSort ? (
+        <div className="flex flex-col">
+          {groupedItems.map((group) => (
+            <div
+              key={group.dateLabel}
+              className="flex flex-col gap-3.75 border-b border-[#E5E5E5] px-4 py-7.5 last:border-b-0"
+            >
+              <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#73787E]">
+                {group.dateLabel}
+              </p>
+              <div className="flex flex-col gap-5">
+                {group.items.map((item) => (
+                  <ExpenseItemRow key={item.id} item={item} showDate={false} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-7.5 px-4 pt-3.75 pb-7.5">
+          {sortedItems.map((item) => (
+            <ExpenseItemRow key={item.id} item={item} showDate={true} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/report/monthly/page.tsx
+++ b/src/app/report/monthly/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import Image from 'next/image';
 import PageHeader from '@/shared/ui/PageHeader';
 import SortButton, { type SortType } from '@/shared/ui/SortButton';
+import EmotionIcon from '@/shared/ui/EmotionIcon';
 import {
   monthlyExpenseMock,
   getMonthlyExpenseTotal,
@@ -73,13 +73,7 @@ function ExpenseItemRow({ item, showDate }: { item: MonthlyExpenseItem; showDate
               <span className="h-3.5 w-px bg-[#D9D9D9]" />
               <div className="flex items-center gap-1.5">
                 {item.emotions.map((emotion) => (
-                  <Image
-                    key={emotion}
-                    src={`/svg/emo/${emotion}.svg`}
-                    alt={emotion}
-                    width={20}
-                    height={20}
-                  />
+                  <EmotionIcon key={emotion} name={emotion} size={20} />
                 ))}
               </div>
             </>

--- a/src/app/report/monthly/page.tsx
+++ b/src/app/report/monthly/page.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Image from 'next/image';
+import PageHeader from '@/shared/ui/PageHeader';
+import SortButton, { type SortType } from '@/shared/ui/SortButton';
+import {
+  monthlyExpenseMock,
+  getMonthlyExpenseTotal,
+  type MonthlyExpenseItem,
+} from '@/features/report/mock/monthlyExpenseMockData';
+
+interface DayGroup {
+  date: string;
+  dateLabel: string;
+  items: MonthlyExpenseItem[];
+}
+
+function groupByDate(items: MonthlyExpenseItem[]): DayGroup[] {
+  const map = new Map<string, DayGroup>();
+  items.forEach((item) => {
+    if (!map.has(item.date)) {
+      map.set(item.date, {
+        date: item.date,
+        dateLabel: item.dateLabel,
+        items: [],
+      });
+    }
+    map.get(item.date)!.items.push(item);
+  });
+  return Array.from(map.values());
+}
+
+function sortItems(items: MonthlyExpenseItem[], sortType: SortType): MonthlyExpenseItem[] {
+  const sorted = [...items];
+  switch (sortType) {
+    case 'latest':
+      return sorted.sort((a, b) => b.date.localeCompare(a.date));
+    case 'oldest':
+      return sorted.sort((a, b) => a.date.localeCompare(b.date));
+    case 'expensive':
+      return sorted.sort((a, b) => b.amount - a.amount);
+    case 'cheap':
+      return sorted.sort((a, b) => a.amount - b.amount);
+    default:
+      return sorted;
+  }
+}
+
+function ExpenseItemRow({ item, showDate }: { item: MonthlyExpenseItem; showDate: boolean }) {
+  return (
+    <div className="flex flex-col gap-1.25">
+      {showDate && (
+        <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#73787E]">
+          {item.dateLabel}
+        </p>
+      )}
+
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
+            {item.tags.map((tag) => (
+              <span
+                key={tag}
+                className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#13278A]"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+          {item.emotions.length > 0 && (
+            <>
+              <span className="h-3.5 w-px bg-[#D9D9D9]" />
+              <div className="flex items-center gap-1.5">
+                {item.emotions.map((emotion) => (
+                  <Image
+                    key={emotion}
+                    src={`/svg/emo/${emotion}.svg`}
+                    alt={emotion}
+                    width={20}
+                    height={20}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+        <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
+          {item.amount.toLocaleString()}원
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+          {item.name ?? ''}
+        </p>
+        <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+          {item.paymentMethod}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function MonthlyExpensePage() {
+  const [sortType, setSortType] = useState<SortType>('latest');
+  const totalAmount = getMonthlyExpenseTotal();
+
+  const isDateSort = sortType === 'latest' || sortType === 'oldest';
+
+  const sortedItems = useMemo(
+    () => sortItems(monthlyExpenseMock, sortType),
+    [sortType],
+  );
+  const groupedItems = useMemo(() => groupByDate(sortedItems), [sortedItems]);
+
+  return (
+    <div className="flex flex-1 flex-col bg-white">
+      <PageHeader title="이번 달 지출" />
+
+      <div className="border-b-[5px] border-[#F7F8FA] px-4 pt-3 pb-5">
+        <p className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#030303]">
+          {totalAmount.toLocaleString()}원
+        </p>
+      </div>
+
+      <div className="flex justify-end px-4 pt-4">
+        <SortButton sortType={sortType} onSortChange={setSortType} />
+      </div>
+
+      {isDateSort ? (
+        <div className="flex flex-col">
+          {groupedItems.map((group) => (
+            <div
+              key={group.date}
+              className="flex flex-col gap-3.75 border-b border-[#E5E5E5] px-4 py-7.5 last:border-b-0"
+            >
+              <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#73787E]">
+                {group.dateLabel}
+              </p>
+              <div className="flex flex-col gap-5">
+                {group.items.map((item) => (
+                  <ExpenseItemRow key={item.id} item={item} showDate={false} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-7.5 px-4 pt-3.75 pb-7.5">
+          {sortedItems.map((item) => (
+            <ExpenseItemRow key={item.id} item={item} showDate={true} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import ReportMonthCard from '@/features/report/ui/ReportMonthCard';
 import ReportEmpty from '@/features/report/ui/ReportEmpty';
 import ReportInsights from '@/features/report/ui/ReportInsights';
@@ -12,7 +13,10 @@ import PageHeader from '@/shared/ui/PageHeader';
 import { reportMockData } from '@/features/report/mock/reportMockData';
 
 export default function ReportPage() {
-  const [month, setMonth] = useState(new Date().getMonth() + 1);
+  const router = useRouter();
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth() + 1);
 
   const { income, expense, insights, categorySummary, categories, emotionSummary, emotions, situationSummary, situations } = reportMockData;
   const hasData = income > 0 || expense > 0;
@@ -24,10 +28,17 @@ export default function ReportPage() {
 
       <div className="flex flex-col gap-6.25 px-4 pt-5 pb-30">
         <ReportMonthCard
+          year={year}
           month={month}
           income={income}
           expense={expense}
-          onMonthChange={setMonth}
+          onYearMonthChange={(ym) => {
+            setYear(ym.year);
+            setMonth(ym.month);
+          }}
+          onExpenseDetailClick={() =>
+            router.push(hasData ? '/report/monthly' : '/record?type=expense')
+          }
         />
 
         {hasData ? (

--- a/src/features/report/mock/monthlyExpenseMockData.ts
+++ b/src/features/report/mock/monthlyExpenseMockData.ts
@@ -1,0 +1,110 @@
+export interface MonthlyExpenseItem {
+  id: string;
+  date: string;
+  dateLabel: string;
+  name?: string;
+  amount: number;
+  paymentMethod: string;
+  tags: string[]; 
+  emotions: string[];
+}
+
+export const monthlyExpenseMock: MonthlyExpenseItem[] = [
+  {
+    id: '1',
+    date: '2026-04-06',
+    dateLabel: '4월 6일 목요일',
+    name: '케이크',
+    amount: 68000,
+    paymentMethod: '카드',
+    tags: ['기분전환', '보상심리'],
+    emotions: ['boring', 'emptiness'],
+  },
+  {
+    id: '2',
+    date: '2026-04-06',
+    dateLabel: '4월 6일 목요일',
+    amount: 42000,
+    paymentMethod: '현금',
+    tags: ['피로회복', '기타'],
+    emotions: ['tired', 'happy'],
+  },
+  {
+    id: '3',
+    date: '2026-04-05',
+    dateLabel: '4월 5일 금요일',
+    name: '하이디라오',
+    amount: 55000,
+    paymentMethod: '카드',
+    tags: ['기분전환'],
+    emotions: ['flut', 'happy'],
+  },
+  {
+    id: '4',
+    date: '2026-04-05',
+    dateLabel: '4월 5일 금요일',
+    amount: 28000,
+    paymentMethod: '카드',
+    tags: ['기분전환'],
+    emotions: ['flut', 'happy'],
+  },
+  {
+    id: '5',
+    date: '2026-04-04',
+    dateLabel: '4월 4일 토요일',
+    amount: 74000,
+    paymentMethod: '카드',
+    tags: ['약속'],
+    emotions: ['thanks'],
+  },
+  {
+    id: '6',
+    date: '2026-04-04',
+    dateLabel: '4월 4일 토요일',
+    amount: 63000,
+    paymentMethod: '카드',
+    tags: ['충동소비', '기분전환'],
+    emotions: ['impulse', 'anxios'],
+  },
+  {
+    id: '7',
+    date: '2026-04-03',
+    dateLabel: '4월 3일 월요일',
+    amount: 48000,
+    paymentMethod: '현금',
+    tags: ['필요'],
+    emotions: ['proud'],
+  },
+  {
+    id: '8',
+    date: '2026-04-03',
+    dateLabel: '4월 3일 월요일',
+    name: '대학교 친구들과 모임',
+    amount: 86000,
+    paymentMethod: '카드',
+    tags: ['충동소비', '기분전환'],
+    emotions: ['impulse', 'depressed'],
+  },
+  {
+    id: '9',
+    date: '2026-04-03',
+    dateLabel: '4월 3일 월요일',
+    amount: 23000,
+    paymentMethod: '현금',
+    tags: ['피로회복'],
+    emotions: ['tired', 'sad'],
+  },
+  {
+    id: '10',
+    date: '2026-04-02',
+    dateLabel: '4월 2일 화요일',
+    amount: 105000,
+    paymentMethod: '카드',
+    tags: ['피로회복'],
+    emotions: ['tired'],
+  },
+];
+
+export function getMonthlyExpenseTotal(): number {
+  return monthlyExpenseMock.reduce((sum, item) => sum + item.amount, 0);
+}

--- a/src/features/report/mock/monthlyExpenseMockData.ts
+++ b/src/features/report/mock/monthlyExpenseMockData.ts
@@ -5,7 +5,7 @@ export interface MonthlyExpenseItem {
   name?: string;
   amount: number;
   paymentMethod: string;
-  tags: string[]; 
+  tags: string[];
   emotions: string[];
 }
 
@@ -18,7 +18,7 @@ export const monthlyExpenseMock: MonthlyExpenseItem[] = [
     amount: 68000,
     paymentMethod: '카드',
     tags: ['기분전환', '보상심리'],
-    emotions: ['boring', 'emptiness'],
+    emotions: ['심심함', '공허함'],
   },
   {
     id: '2',
@@ -27,7 +27,7 @@ export const monthlyExpenseMock: MonthlyExpenseItem[] = [
     amount: 42000,
     paymentMethod: '현금',
     tags: ['피로회복', '기타'],
-    emotions: ['tired', 'happy'],
+    emotions: ['피곤함', '기쁨'],
   },
   {
     id: '3',
@@ -37,7 +37,7 @@ export const monthlyExpenseMock: MonthlyExpenseItem[] = [
     amount: 55000,
     paymentMethod: '카드',
     tags: ['기분전환'],
-    emotions: ['flut', 'happy'],
+    emotions: ['설렘', '기쁨'],
   },
   {
     id: '4',
@@ -46,7 +46,7 @@ export const monthlyExpenseMock: MonthlyExpenseItem[] = [
     amount: 28000,
     paymentMethod: '카드',
     tags: ['기분전환'],
-    emotions: ['flut', 'happy'],
+    emotions: ['설렘', '기쁨'],
   },
   {
     id: '5',
@@ -55,7 +55,7 @@ export const monthlyExpenseMock: MonthlyExpenseItem[] = [
     amount: 74000,
     paymentMethod: '카드',
     tags: ['약속'],
-    emotions: ['thanks'],
+    emotions: ['고마움'],
   },
   {
     id: '6',
@@ -64,7 +64,7 @@ export const monthlyExpenseMock: MonthlyExpenseItem[] = [
     amount: 63000,
     paymentMethod: '카드',
     tags: ['충동소비', '기분전환'],
-    emotions: ['impulse', 'anxios'],
+    emotions: ['충동', '불안함'],
   },
   {
     id: '7',
@@ -73,7 +73,7 @@ export const monthlyExpenseMock: MonthlyExpenseItem[] = [
     amount: 48000,
     paymentMethod: '현금',
     tags: ['필요'],
-    emotions: ['proud'],
+    emotions: ['뿌듯함'],
   },
   {
     id: '8',
@@ -83,7 +83,7 @@ export const monthlyExpenseMock: MonthlyExpenseItem[] = [
     amount: 86000,
     paymentMethod: '카드',
     tags: ['충동소비', '기분전환'],
-    emotions: ['impulse', 'depressed'],
+    emotions: ['충동', '우울함'],
   },
   {
     id: '9',
@@ -92,7 +92,7 @@ export const monthlyExpenseMock: MonthlyExpenseItem[] = [
     amount: 23000,
     paymentMethod: '현금',
     tags: ['피로회복'],
-    emotions: ['tired', 'sad'],
+    emotions: ['피곤함', '슬픔'],
   },
   {
     id: '10',
@@ -101,7 +101,7 @@ export const monthlyExpenseMock: MonthlyExpenseItem[] = [
     amount: 105000,
     paymentMethod: '카드',
     tags: ['피로회복'],
-    emotions: ['tired'],
+    emotions: ['피곤함'],
   },
 ];
 

--- a/src/features/report/ui/CategoryChart.tsx
+++ b/src/features/report/ui/CategoryChart.tsx
@@ -63,7 +63,7 @@ export default function CategoryChart({ summary, categories }: CategoryChartProp
     <div className="flex flex-col gap-5 rounded-[12px] bg-[#F7F8FA] py-5 px-4">
       <div className="flex flex-col gap-0.5">
         <h2 className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
-          카테고리별 주요 지출 항목
+          카테고리별 지출 항목
         </h2>
         <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#73787E]">
           {(() => {

--- a/src/features/report/ui/EmotionList.tsx
+++ b/src/features/report/ui/EmotionList.tsx
@@ -1,32 +1,14 @@
 'use client';
 
 import { useState } from 'react';
-import Image from 'next/image';
 import Link from 'next/link';
+import EmotionIcon from '@/shared/ui/EmotionIcon';
 import type { EmotionItem } from '@/features/report/mock/reportMockData';
 
 interface EmotionListProps {
   summary: string;
   emotions: EmotionItem[];
 }
-
-const EMOTION_NAME_TO_SVG: Record<string, string> = {
-  심심함: 'boring',
-  공허함: 'emptiness',
-  피곤함: 'tired',
-  기쁨: 'happy',
-  설렘: 'flut',
-  뿌듯함: 'proud',
-  고마움: 'thanks',
-  짜증: 'annoy',
-  화남: 'angry',
-  충동: 'impulse',
-  불안함: 'anxios',
-  우울함: 'depressed',
-  슬픔: 'sad',
-  스트레스: 'stress',
-  외로움: 'lonely',
-};
 
 export default function EmotionList({ summary, emotions }: EmotionListProps) {
   const [expanded, setExpanded] = useState(false);
@@ -55,16 +37,7 @@ export default function EmotionList({ summary, emotions }: EmotionListProps) {
                 {item.rank}
               </span>
               <div className="flex items-center gap-2">
-                {EMOTION_NAME_TO_SVG[item.name] ? (
-                  <Image
-                    src={`/svg/emo/${EMOTION_NAME_TO_SVG[item.name]}.svg`}
-                    alt={item.name}
-                    width={24}
-                    height={24}
-                  />
-                ) : (
-                  <span className="text-[20px] leading-none">{item.emoji}</span>
-                )}
+                <EmotionIcon name={item.name} size={24} />
                 <span className="text-[18px] font-medium tracking-[-0.45px] text-[#1C1D1F]">
                   {item.name}
                 </span>

--- a/src/features/report/ui/EmotionList.tsx
+++ b/src/features/report/ui/EmotionList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import type { EmotionItem } from '@/features/report/mock/reportMockData';
 
@@ -8,6 +9,24 @@ interface EmotionListProps {
   summary: string;
   emotions: EmotionItem[];
 }
+
+const EMOTION_NAME_TO_SVG: Record<string, string> = {
+  심심함: 'boring',
+  공허함: 'emptiness',
+  피곤함: 'tired',
+  기쁨: 'happy',
+  설렘: 'flut',
+  뿌듯함: 'proud',
+  고마움: 'thanks',
+  짜증: 'annoy',
+  화남: 'angry',
+  충동: 'impulse',
+  불안함: 'anxios',
+  우울함: 'depressed',
+  슬픔: 'sad',
+  스트레스: 'stress',
+  외로움: 'lonely',
+};
 
 export default function EmotionList({ summary, emotions }: EmotionListProps) {
   const [expanded, setExpanded] = useState(false);
@@ -17,7 +36,7 @@ export default function EmotionList({ summary, emotions }: EmotionListProps) {
     <div className="flex flex-col gap-7.5 rounded-[12px] bg-[#F7F8FA] py-5 px-4">
       <div className="flex flex-col gap-0.5">
         <h2 className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#1C1D1F]">
-          감정별 주요 지출 항목
+          감정별 지출 항목
         </h2>
         <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#73787E]">
           {summary}
@@ -36,7 +55,16 @@ export default function EmotionList({ summary, emotions }: EmotionListProps) {
                 {item.rank}
               </span>
               <div className="flex items-center gap-2">
-                <span className="text-[20px] leading-none">{item.emoji}</span>
+                {EMOTION_NAME_TO_SVG[item.name] ? (
+                  <Image
+                    src={`/svg/emo/${EMOTION_NAME_TO_SVG[item.name]}.svg`}
+                    alt={item.name}
+                    width={24}
+                    height={24}
+                  />
+                ) : (
+                  <span className="text-[20px] leading-none">{item.emoji}</span>
+                )}
                 <span className="text-[18px] font-medium tracking-[-0.45px] text-[#1C1D1F]">
                   {item.name}
                 </span>

--- a/src/features/report/ui/MonthPickerBottomSheet.tsx
+++ b/src/features/report/ui/MonthPickerBottomSheet.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Image from 'next/image';
+
+const ITEM_HEIGHT = 40;
+const VISIBLE_BUFFER = 3;
+const SPACER_HEIGHT = ITEM_HEIGHT * VISIBLE_BUFFER;
+const CONTAINER_HEIGHT = ITEM_HEIGHT * (VISIBLE_BUFFER * 2 + 1);
+const ANIMATION_DURATION = 300;
+const SELECTABLE_MONTHS = 36;
+
+export interface YearMonth {
+  year: number;
+  month: number;
+}
+
+interface MonthPickerBottomSheetProps {
+  isOpen: boolean;
+  selectedYear: number;
+  selectedMonth: number;
+  onChange: (yearMonth: YearMonth) => void;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+function generateAllMonths(): YearMonth[] {
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth() + 1;
+
+  const startDate = new Date(currentYear, currentMonth - 1 - (SELECTABLE_MONTHS - 1), 1);
+  const startYear = startDate.getFullYear();
+  const startMonth = startDate.getMonth() + 1;
+
+  const result: YearMonth[] = [];
+  let y = startYear;
+  let m = startMonth;
+  while (y < currentYear || (y === currentYear && m <= 12)) {
+    result.push({ year: y, month: m });
+    if (m === 12) {
+      m = 1;
+      y++;
+    } else {
+      m++;
+    }
+  }
+  return result;
+}
+
+function isMonthDisabled(ym: YearMonth): boolean {
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth() + 1;
+  return (
+    ym.year > currentYear ||
+    (ym.year === currentYear && ym.month > currentMonth)
+  );
+}
+
+export default function MonthPickerBottomSheet({
+  isOpen,
+  selectedYear,
+  selectedMonth,
+  onChange,
+  onConfirm,
+  onClose,
+}: MonthPickerBottomSheetProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const isProgrammaticScroll = useRef(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+  const [centeredIndex, setCenteredIndex] = useState(0);
+
+  const months = useMemo(() => generateAllMonths(), []);
+  const currentSystemYear = new Date().getFullYear();
+
+  const selectedIndex = useMemo(
+    () => months.findIndex((m) => m.year === selectedYear && m.month === selectedMonth),
+    [months, selectedYear, selectedMonth],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    document.body.style.overflow = 'hidden';
+    requestAnimationFrame(() => setIsVisible(true));
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !scrollRef.current || selectedIndex < 0) return;
+    isProgrammaticScroll.current = true;
+    scrollRef.current.scrollTop = selectedIndex * ITEM_HEIGHT;
+    setCenteredIndex(selectedIndex);
+    setTimeout(() => {
+      isProgrammaticScroll.current = false;
+    }, 100);
+  }, [isOpen, selectedIndex]);
+
+  const handleClose = () => {
+    setIsClosing(true);
+    setTimeout(() => {
+      setIsVisible(false);
+      setIsClosing(false);
+      onClose();
+    }, ANIMATION_DURATION);
+  };
+
+  const handleConfirm = () => {
+    setIsClosing(true);
+    setTimeout(() => {
+      setIsVisible(false);
+      setIsClosing(false);
+      onConfirm();
+    }, ANIMATION_DURATION);
+  };
+
+  const handleScroll = () => {
+    if (!scrollRef.current || isProgrammaticScroll.current) return;
+    const scrollTop = scrollRef.current.scrollTop;
+    const index = Math.round(scrollTop / ITEM_HEIGHT);
+    const newYM = months[index];
+    if (!newYM) return;
+    setCenteredIndex(index);
+    if (
+      !isMonthDisabled(newYM) &&
+      (newYM.year !== selectedYear || newYM.month !== selectedMonth)
+    ) {
+      onChange(newYM);
+    }
+  };
+
+  const getColorByDistance = (distance: number, disabled: boolean): string => {
+    if (disabled) return 'text-[#E5E5E5]';
+    if (distance === 0) return 'text-[#1C1D1F]';
+    if (distance === 1) return 'text-[#474C52]';
+    if (distance === 2) return 'text-[#9FA4A8]';
+    if (distance === 3) return 'text-[#CACDD2]';
+    return 'text-transparent';
+  };
+
+  if (!isOpen) return null;
+
+  const isShowing = isVisible && !isClosing;
+  const centeredYM = months[centeredIndex];
+  const isCenteredDisabled = centeredYM ? isMonthDisabled(centeredYM) : false;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center"
+      onClick={handleClose}
+    >
+      <div
+        className={`absolute inset-0 bg-black/50 transition-opacity duration-300 ${
+          isShowing ? 'opacity-100' : 'opacity-0'
+        }`}
+      />
+
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className={`relative flex w-full max-w-md flex-col rounded-t-[20px] bg-white transition-transform duration-300 ease-out ${
+          isShowing ? 'translate-y-0' : 'translate-y-full'
+        }`}
+      >
+        <div className="flex items-center justify-between px-4 pt-10 pb-2">
+          <h2 className="text-[18px] font-medium leading-normal tracking-[-0.45px] text-[#27282C]">
+            월 설정
+          </h2>
+          <button onClick={handleClose} aria-label="닫기">
+            <Image src="/icons/icon_X.svg" alt="" width={28} height={28} />
+          </button>
+        </div>
+
+        <div className="relative mx-4 mt-13.5">
+          <div
+            className="pointer-events-none absolute left-0 right-0 top-1/2 -translate-y-1/2 rounded-[41px] bg-[#F7F8FA]"
+            style={{ height: ITEM_HEIGHT }}
+          />
+
+          <div
+            ref={scrollRef}
+            onScroll={handleScroll}
+            className="relative overflow-y-scroll snap-y snap-mandatory [&::-webkit-scrollbar]:hidden"
+            style={{
+              height: CONTAINER_HEIGHT,
+              scrollbarWidth: 'none',
+            }}
+          >
+            <div style={{ height: SPACER_HEIGHT }} />
+
+            {months.map((ym, i) => {
+              const distance = Math.abs(i - centeredIndex);
+              const disabled = isMonthDisabled(ym);
+              const isSelected = distance === 0;
+              const showYear = ym.year !== currentSystemYear;
+              const label = showYear ? `${ym.year}년 ${ym.month}월` : `${ym.month}월`;
+              return (
+                <div
+                  key={`${ym.year}-${ym.month}`}
+                  className={`flex snap-center items-center justify-center ${getColorByDistance(distance, disabled)} ${
+                    isSelected
+                      ? 'text-[20px] font-semibold tracking-[-0.5px]'
+                      : 'text-[18px] font-medium tracking-[-0.45px]'
+                  } leading-normal`}
+                  style={{ height: ITEM_HEIGHT }}
+                >
+                  {label}
+                </div>
+              );
+            })}
+
+            <div style={{ height: SPACER_HEIGHT }} />
+          </div>
+        </div>
+
+        <div className="px-4.25 pt-6 pb-9">
+          <button
+            onClick={handleConfirm}
+            disabled={isCenteredDisabled}
+            className={`flex h-13.5 w-full items-center justify-center rounded-[10px] ${
+              isCenteredDisabled ? 'bg-[#CACDD2]' : 'bg-[#13278A]'
+            }`}
+          >
+            <span className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-white">
+              확인
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/report/ui/ReportEmpty.tsx
+++ b/src/features/report/ui/ReportEmpty.tsx
@@ -1,6 +1,6 @@
 const SECTIONS = [
-  { id: 'category', title: '카테고리별 주요 지출 항목', height: 'h-58.25', titleColor: 'text-[#030303]' },
-  { id: 'emotion', title: '감정별 주요 지출 항목', height: 'h-58.25', titleColor: 'text-[#030303]' },
+  { id: 'category', title: '카테고리별 지출 항목', height: 'h-58.25', titleColor: 'text-[#030303]' },
+  { id: 'emotion', title: '감정별 지출 항목', height: 'h-58.25', titleColor: 'text-[#030303]' },
   { id: 'situation', title: '자주 선택한 상황 태그', height: 'h-70', titleColor: 'text-[#1C1D1F]' },
 ];
 

--- a/src/features/report/ui/ReportInsights.tsx
+++ b/src/features/report/ui/ReportInsights.tsx
@@ -11,7 +11,7 @@ export default function ReportInsights({ userName, insights }: ReportInsightsPro
       <h2 className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
         이번 달 {userName}님은
       </h2>
-      <div className="flex flex-col gap-2 rounded-[12px] border border-[#F0F0F0] bg-[#F7F8FA] p-3.5">
+      <div className="flex flex-col gap-2 rounded-[12px] border border-[#F0F0F0] bg-[#F7F8FA] py-3.5 px-4">
         {insights.map((insight) => (
           <img
             key={insight.id}

--- a/src/features/report/ui/ReportMonthCard.tsx
+++ b/src/features/report/ui/ReportMonthCard.tsx
@@ -1,60 +1,69 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
+import MonthPickerBottomSheet, { type YearMonth } from './MonthPickerBottomSheet';
 
 interface ReportMonthCardProps {
+  year: number;
   month: number;
   income: number;
   expense: number;
-  onMonthChange: (month: number) => void;
+  onYearMonthChange: (yearMonth: YearMonth) => void;
+  onExpenseDetailClick?: () => void;
 }
 
-const MONTHS = Array.from({ length: 12 }, (_, i) => i + 1);
-
 export default function ReportMonthCard({
+  year,
   month,
   income,
   expense,
-  onMonthChange,
+  onYearMonthChange,
+  onExpenseDetailClick,
 }: ReportMonthCardProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  const handleSelect = (m: number) => {
-    onMonthChange(m);
-    setIsOpen(false);
-  };
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [pendingYear, setPendingYear] = useState(year);
+  const [pendingMonth, setPendingMonth] = useState(month);
 
   const hasExpense = expense > 0;
+  const isEmpty = income === 0 && expense === 0;
+  const currentSystemYear = new Date().getFullYear();
+  const monthLabel =
+    year === currentSystemYear ? `${month}월` : `${year}년 ${month}월`;
+
+  const handleOpenPicker = () => {
+    setPendingYear(year);
+    setPendingMonth(month);
+    setIsPickerOpen(true);
+  };
+
+  const handleChange = (ym: YearMonth) => {
+    setPendingYear(ym.year);
+    setPendingMonth(ym.month);
+  };
+
+  const handleConfirm = () => {
+    onYearMonthChange({ year: pendingYear, month: pendingMonth });
+    setIsPickerOpen(false);
+  };
 
   return (
-    <div className="flex h-22 w-full items-center gap-3.75 rounded-[12px] border border-[#F0F0F0] bg-[#F7F8FA] px-4 py-3.5">
-
-      <div ref={dropdownRef} className="relative">
+    <>
+      <div className="flex flex-col gap-3">
+        {/* 월 표시 (카드 외부) */}
         <button
-          onClick={() => setIsOpen((prev) => !prev)}
-          className="flex items-center gap-1.25"
-          aria-expanded={isOpen}
+          onClick={handleOpenPicker}
+          className="flex w-fit items-center gap-0.5"
+          aria-expanded={isPickerOpen}
         >
-          <span className="text-[28px] font-semibold leading-normal tracking-[-0.7px] text-[#030303]">
-            {month}월
+          <span className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
+            {monthLabel}
           </span>
           <svg
             width="20"
             height="20"
             viewBox="0 0 20 20"
             fill="none"
-            className={`transition-transform ${isOpen ? 'rotate-180' : ''}`}
+            className={`transition-transform ${isPickerOpen ? 'rotate-180' : ''}`}
           >
             <path
               d="M5 7.5L10 12.5L15 7.5"
@@ -66,52 +75,49 @@ export default function ReportMonthCard({
           </svg>
         </button>
 
-        {isOpen && (
-          <ul className="absolute left-0 top-full z-20 mt-1 max-h-60 w-25 overflow-y-auto rounded-lg border border-[#E5E5E5] bg-white py-1 shadow-lg">
-            {MONTHS.map((m) => (
-              <li key={m}>
-                <button
-                  onClick={() => handleSelect(m)}
-                  className={`w-full px-4 py-2 text-left text-[16px] font-medium tracking-[-0.4px] hover:bg-[#F7F8FA] ${
-                    m === month
-                      ? 'text-[#13278A] font-semibold'
-                      : 'text-[#474C52]'
-                  }`}
-                >
-                  {m}월
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+        <div className="flex flex-col gap-4.5 rounded-[12px] border border-[#F0F0F0] bg-[#F7F8FA] p-4">
+          <div className="flex flex-col">
+            <div className="flex items-center justify-between">
+              <span className="text-[18px] font-medium leading-normal tracking-[-0.45px] text-[#474C52]">
+                수입
+              </span>
+              <span className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#030303]">
+                {income.toLocaleString()}원
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-[18px] font-medium leading-normal tracking-[-0.45px] text-[#474C52]">
+                지출
+              </span>
+              <span
+                className={`text-[24px] font-semibold leading-normal tracking-[-0.6px] ${
+                  hasExpense ? 'text-[#EB1C1C]' : 'text-[#030303]'
+                }`}
+              >
+                {expense.toLocaleString()}원
+              </span>
+            </div>
+          </div>
 
-      <div className="flex flex-1 items-center gap-5">
-        <div className="h-11.25 w-0.5 bg-[#E5E5E5]" />
-
-        <div className="flex flex-1 flex-col justify-between gap-0">
-        <div className="flex items-center gap-3.75">
-          <span className="w-7 text-center text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#474C52]">
-            수입
-          </span>
-          <span className="flex-1 text-right text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
-            {income.toLocaleString()}원
-          </span>
-        </div>
-        <div className="flex items-center gap-3.75">
-          <span className="w-7 text-center text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#474C52]">
-            지출
-          </span>
-          <span
-            className={`flex-1 text-right text-[20px] font-semibold leading-normal tracking-[-0.5px] ${
-              hasExpense ? 'text-[#EB1C1C]' : 'text-[#030303]'
-            }`}
+          <button
+            onClick={onExpenseDetailClick}
+            className="flex h-11 w-full items-center justify-center rounded-[8px] bg-white shadow-[0px_0px_4px_rgba(19,39,138,0.08)]"
           >
-            {expense.toLocaleString()}원
-          </span>
+            <span className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#27282C]">
+              {isEmpty ? '지출 기록하기' : '이번 달 지출 확인하기'}
+            </span>
+          </button>
         </div>
       </div>
-      </div>
-    </div>
+
+      <MonthPickerBottomSheet
+        isOpen={isPickerOpen}
+        selectedYear={pendingYear}
+        selectedMonth={pendingMonth}
+        onChange={handleChange}
+        onConfirm={handleConfirm}
+        onClose={() => setIsPickerOpen(false)}
+      />
+    </>
   );
 }

--- a/src/features/report/ui/ReportMonthCard.tsx
+++ b/src/features/report/ui/ReportMonthCard.tsx
@@ -49,7 +49,6 @@ export default function ReportMonthCard({
   return (
     <>
       <div className="flex flex-col gap-3">
-        {/* 월 표시 (카드 외부) */}
         <button
           onClick={handleOpenPicker}
           className="flex w-fit items-center gap-0.5"

--- a/src/shared/constants/emotionMap.ts
+++ b/src/shared/constants/emotionMap.ts
@@ -1,0 +1,22 @@
+export const EMOTION_NAME_TO_SVG: Record<string, string> = {
+  기쁨: 'happy',
+  설렘: 'flut',
+  뿌듯함: 'proud',
+  고마움: 'thanks',
+  짜증: 'annoy',
+  화남: 'angry',
+  불안함: 'anxios',
+  슬픔: 'sad',
+  스트레스: 'stress',
+  우울함: 'depressed',
+  심심함: 'boring',
+  피곤함: 'tired',
+  공허함: 'emptiness',
+  외로움: 'lonely',
+  충동: 'impulse',
+};
+
+export function getEmotionSvgPath(name: string): string | null {
+  const key = EMOTION_NAME_TO_SVG[name];
+  return key ? `/svg/emo/${key}.svg` : null;
+}

--- a/src/shared/ui/EmotionIcon.tsx
+++ b/src/shared/ui/EmotionIcon.tsx
@@ -1,0 +1,13 @@
+import Image from 'next/image';
+import { getEmotionSvgPath } from '@/shared/constants/emotionMap';
+
+interface EmotionIconProps {
+  name: string;
+  size?: number;
+}
+
+export default function EmotionIcon({ name, size = 24 }: EmotionIconProps) {
+  const src = getEmotionSvgPath(name);
+  if (!src) return null;
+  return <Image src={src} alt={name} width={size} height={size} />;
+}

--- a/src/shared/ui/SortButton.tsx
+++ b/src/shared/ui/SortButton.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import { cn } from '@/lib/utils';
 import { useClickOutside } from '@/shared/hooks';
 
-type SortType = 'latest' | 'expensive' | 'cheap';
+export type SortType = 'latest' | 'oldest' | 'expensive' | 'cheap';
 
 interface SortButtonProps {
   sortType: SortType;
@@ -18,6 +18,7 @@ export default function SortButton({ sortType, onSortChange }: SortButtonProps) 
 
   const sortOptions: Array<{ value: SortType; label: string }> = [
     { value: 'latest', label: '최신순' },
+    { value: 'oldest', label: '오래된 순' },
     { value: 'expensive', label: '금액 높은 순' },
     { value: 'cheap', label: '금액 낮은 순' },
   ];

--- a/src/widgets/export/ExportContent.tsx
+++ b/src/widgets/export/ExportContent.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils';
 import PageHeader from '@/shared/ui/PageHeader';
 import SortButton from '@/shared/ui/SortButton';
 
-type SortType = 'latest' | 'expensive' | 'cheap';
+type SortType = 'latest' | 'oldest' | 'expensive' | 'cheap';
 
 const TODAY = '2026-04-21';
 
@@ -47,6 +47,8 @@ export default function ExportContent() {
         return [...items].sort((a, b) => b.amount - a.amount);
       case 'cheap':
         return [...items].sort((a, b) => a.amount - b.amount);
+      case 'oldest':
+        return [...items].reverse();
       case 'latest':
       default:
         return items;


### PR DESCRIPTION
## 작업 내용                            
                                                                             
  ### 월 선택 카드 (ReportMonthCard)                                         
  - 월 표시를 카드 외부 상단으로 분리                             
  - "이번 달 지출 확인하기" 버튼 추가 (빈 상태일 땐 "지출 기록하기")
                                          
  ### 월 선택 휠 피커 (MonthPickerBottomSheet 신규)
  - 바텀시트 + 슬라이드업 애니메이션                                         
  - CSS scroll-snap 기반 휠 피커 (추후 필요시 라이브러리 사용 예정)        
  - 최근 36개월 선택 가능, 이번 연도 미래월은 비활성화 (디자인 임시)                      
                                                                             
  ### 이번 달 지출 페이지 신규 (/report/monthly)
  - 헤더 + 합계 + 정렬 필터 + 일별 그룹 리스트                               
  - SortButton 4개 옵션 (최신/오래된/높은/낮은)
  - 정렬 방식에 따라 레이아웃 분기                                           
                                                                             
  ### 카테고리/감정 상세 페이지 개편
  - 공통 PageHeader 적용                                                     
  - 월 네비게이션 제거
  - 헤더 영역 디자인 정리                     
  - SortButton + 정렬 분기 로직 추가      

  ### 리포트 메인 디자인 정리                                                
  - "주요 지출 항목" → "지출 항목" 텍스트 통일
  - 인사이트 영역 padding 조정                                               
  - 빈 상태 버튼 텍스트 조건부 분기
                                                                             
  ### 감정 아이콘 공통 컴포넌트 통합      
  - shared/constants/emotionMap.ts 매핑 추가                                 
  - shared/ui/EmotionIcon.tsx 컴포넌트 추출                                  
  - 4곳 사용처 인라인 매핑 제거