### PR TITLE
[FIX] 가계부 캘린더 페이지 디자인 수정사항 반영

### DIFF
--- a/src/features/calendar/mock/calendarMockData.ts
+++ b/src/features/calendar/mock/calendarMockData.ts
@@ -4,6 +4,7 @@ export interface CalendarExpenseItem {
   amount: number;
   paymentMethod: string;
   memo?: string;
+  emotions?: string[];
 }
 
 export interface CalendarDailyData {
@@ -17,27 +18,31 @@ export const dailyCalendarMock: Record<number, CalendarDailyData> = {
     income: 200000,
     expense: 75000,
     expenseItems: [
-      { category: '식비', tags: ['약속', '보상심리'], amount: 28000, paymentMethod: '카드', memo: '친구 생일 저녁' },
-      { category: '카페', tags: ['기분전환'], amount: 12000, paymentMethod: '현금' },
-      { category: '디저트', tags: ['보상심리'], amount: 9000, paymentMethod: '카드', memo: '두쫀쿠' },
-      { category: '생필품', tags: ['필요'], amount: 14000, paymentMethod: '체크카드' },
-      { category: '교통', tags: ['피로회복'], amount: 8000, paymentMethod: '카드' },
-      { category: '편의점', tags: ['충동소비'], amount: 4000, paymentMethod: '현금', memo: '간식' },
+      { category: '식비', tags: ['약속', '보상심리'], amount: 28000, paymentMethod: '카드', memo: '친구 생일 저녁', emotions: ['기쁨', '고마움'] },
+      { category: '카페', tags: ['기분전환'], amount: 12000, paymentMethod: '현금', emotions: ['설렘'] },
+      { category: '디저트', tags: ['보상심리'], amount: 9000, paymentMethod: '카드', memo: '두쫀쿠', emotions: ['기쁨'] },
+      { category: '생필품', tags: ['필요'], amount: 14000, paymentMethod: '체크카드', emotions: ['뿌듯함'] },
+      { category: '교통', tags: ['피로회복'], amount: 8000, paymentMethod: '카드', emotions: ['피곤함'] },
+      { category: '편의점', tags: ['충동소비'], amount: 4000, paymentMethod: '현금', memo: '간식', emotions: ['충동'] },
     ],
   },
   7: {
     income: 0,
     expense: 50000,
     expenseItems: [
-      { category: '카페', tags: ['기분전환'], amount: 25000, paymentMethod: '카드', memo: '스타벅스' },
-      { category: '생필품', tags: ['필요'], amount: 25000, paymentMethod: '체크카드', memo: '다이소' },
+      { category: '카페', tags: ['기분전환'], amount: 25000, paymentMethod: '카드', memo: '스타벅스', emotions: ['설렘'] },
+      { category: '생필품', tags: ['필요'], amount: 25000, paymentMethod: '체크카드', memo: '다이소', emotions: ['뿌듯함'] },
     ],
   },
   10: {
     income: 0,
-    expense: 42000,
+    expense: 76000,
     expenseItems: [
-      { category: '식비', tags: ['보상심리'], amount: 42000, paymentMethod: '카드', memo: '혼밥' },
+      { category: '카페', tags: ['기분전환', '보상심리'], amount: 12000, paymentMethod: '현금', emotions: ['스트레스', '기쁨'] },
+      { category: '취미', tags: ['기분전환', '할인'], amount: 12000, paymentMethod: '카드', memo: '피규어 신상 구매', emotions: ['설렘', '뿌듯함'] },
+      { category: '생필품', tags: ['필요'], amount: 5000, paymentMethod: '카드', memo: '다이소', emotions: ['뿌듯함'] },
+      { category: '식비', tags: ['약속'], amount: 42000, paymentMethod: '체크카드', emotions: ['충동'] },
+      { category: '교통비', tags: ['지각'], amount: 5000, paymentMethod: '현금', emotions: ['짜증'] },
     ],
   },
 };

--- a/src/features/calendar/ui/CalendarHeader.tsx
+++ b/src/features/calendar/ui/CalendarHeader.tsx
@@ -40,7 +40,7 @@ export default function CalendarHeader({
             className={isCurrentMonth ? '' : 'opacity-100'}
           />
         </button>
-        <span className={`text-center text-[18px] font-bold leading-normal tracking-[-0.45px] text-[#27282C] ${year === currentYear ? 'w-[54px]' : ''}`}>
+        <span className={`text-center text-[18px] font-bold leading-normal tracking-[-0.45px] text-[#27282C] ${year === currentYear ? 'w-13.5' : ''}`}>
           {label}
         </span>
         <button onClick={onNextMonth} disabled={isNextDisabled}>
@@ -54,7 +54,6 @@ export default function CalendarHeader({
         </button>
       </div>
 
-      {/* 수입 / 지출 / 합계 (임시 값 출력) */}
       <div className="flex w-full justify-center">
         <div className="flex">
           <div className="flex w-29.25 flex-col items-center px-2.5 py-0.75 pb-1.5">

--- a/src/features/calendar/ui/DateBottomSheet.tsx
+++ b/src/features/calendar/ui/DateBottomSheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import EmotionIcon from '@/shared/ui/EmotionIcon';
 
 interface ExpenseItem {
   category: string;
@@ -8,6 +9,7 @@ interface ExpenseItem {
   amount: number;
   paymentMethod: string;
   memo?: string;
+  emotions?: string[];
 }
 
 interface DayDetailSheetProps {
@@ -63,87 +65,118 @@ export default function DateBottomSheet({
       />
 
       <div
-        className={`relative flex w-full max-w-md flex-col rounded-t-[20px] bg-white px-4 pt-10 transition-transform duration-300 ease-out ${
-          isEmpty ? 'h-107.25' : 'max-h-[calc(100dvh-89px)] pb-10'
+        className={`relative flex w-full max-w-md flex-col rounded-t-[20px] bg-white pb-10 transition-transform duration-300 ease-out ${
+          isEmpty ? 'h-107.25' : 'max-h-[calc(100dvh-113px)] pt-10'
         } ${isOpen && !isClosing ? 'translate-y-0' : 'translate-y-full'}`}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between">
-          <p className="text-[18px] font-medium leading-normal tracking-[-0.45px] text-[#27282C]">
-            {dateLabel}
-          </p>
-          <button onClick={handleClose} className="size-7" aria-label="닫기">
-            <img src="/icons/icon_X.svg" alt="" width={28} height={28} />
-          </button>
-        </div>
-
         {isEmpty ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-0 pb-10">
-            <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#474C52]">
-              지출 기록이 아직 없어요
-            </p>
-            <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#9FA4A8]">
-              오늘의 소비와 감정을 함께 기록해보세요
-            </p>
-          </div>
-        ) : (
-          <div className="mt-5 flex flex-col gap-5 overflow-y-auto">
-            <div className="flex flex-col gap-1.25">
-              <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
-                수입
+          <>
+            <div className="flex items-center justify-between px-4 pt-7.25">
+              <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#27282C]">
+                {dateLabel}
               </p>
-              <p className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#030303]">
-                {income.toLocaleString()}원
-              </p>
+              <button onClick={handleClose} aria-label="닫기">
+                <img src="/icons/icon_X.svg" alt="" width={28} height={28} />
+              </button>
             </div>
 
-            <div className="flex flex-col gap-1.25">
-              <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
-                지출
+            <div className="flex flex-1 flex-col items-center justify-center pb-10">
+              <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#474C52]">
+                지출 기록이 아직 없어요
               </p>
-              <div className="flex items-center border-b border-[#E5E5E5] pb-3.75">
+              <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#9FA4A8]">
+                오늘의 소비와 감정을 함께 기록해보세요
+              </p>
+            </div>
+          </>
+        ) : (
+          <>
+
+            <button
+              onClick={handleClose}
+              className="absolute right-4 top-3.5"
+              aria-label="닫기"
+            >
+              <img src="/icons/icon_X.svg" alt="" width={28} height={28} />
+            </button>
+          <div className="flex flex-col gap-5 overflow-y-auto">
+            <div className="flex flex-col gap-5">
+              <div className="flex flex-col gap-1.25 px-4">
+                <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
+                  수입
+                </p>
+                <p className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#030303]">
+                  {income.toLocaleString()}원
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-1.25 border-b border-[#E5E5E5] px-4 pb-3.75">
+                <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
+                  지출
+                </p>
                 <p className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#EB1C1C]">
                   {expense.toLocaleString()}원
                 </p>
               </div>
             </div>
 
-            {/* 지출 항목 리스트 */}
-            <div className="flex flex-col gap-5">
-              {expenseItems.map((item, index) => (
-                <div key={index} className="flex flex-col gap-0.75">
-                  <div className="flex items-center justify-between">
-                    <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
-                      {item.category}
-                    </p>
-                    <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
-                      {item.amount.toLocaleString()}원
-                    </p>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-1.5">
-                      {item.tags.map((tag) => (
-                        <span
-                          key={tag}
-                          className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#13278A]"
-                        >
-                          #{tag}
-                        </span>
-                      ))}
+            <div className="flex flex-col gap-2.5 px-4">
+              <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#73787E]">
+                {dateLabel}
+              </p>
+              <div className="flex flex-col gap-5">
+                {expenseItems.map((item, index) => (
+                  <div key={index} className="flex flex-col gap-0.75">
+
+                    <div className="flex items-center justify-between">
+                      <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
+                        {item.category}
+                      </p>
+                      <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
+                        {item.amount.toLocaleString()}원
+                      </p>
                     </div>
-                    <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
-                      {item.paymentMethod}
-                    </p>
+
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-1.5">
+                          {item.tags.map((tag) => (
+                            <span
+                              key={tag}
+                              className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#13278A]"
+                            >
+                              #{tag}
+                            </span>
+                          ))}
+                        </div>
+                        {item.emotions && item.emotions.length > 0 && (
+                          <>
+                            <span className="h-3.5 w-px bg-[#E5E5E5]" />
+                            <div className="flex items-center gap-1.5">
+                              {item.emotions.map((emotion) => (
+                                <EmotionIcon key={emotion} name={emotion} size={24} />
+                              ))}
+                            </div>
+                          </>
+                        )}
+                      </div>
+                      <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+                        {item.paymentMethod}
+                      </p>
+                    </div>
+
+                    {item.memo && (
+                      <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+                        {item.memo}
+                      </p>
+                    )}
                   </div>
-                  {item.memo && (
-                    <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
-                      {item.memo}
-                    </p>
-                  )}
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
           </div>
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
## 작업 내용                                                         
                                          
  ### 1. 바텀시트 레이아웃 개편 (DateBottomSheet)                      
  - **헤더 구조 변경**: 빈 상태/데이터 상태 분기                       
    - 빈 상태: 날짜(좌) + X(우) 한 줄                                  
    - 데이터 상태: X 버튼만 우상단 absolute                            
  - **수입/지출 영역**: 인라인 → 각자 별도 섹션     
  - **지출 영역 border-bottom 추가**                                   
  - **날짜 라벨 위치 변경**: 헤더 → 수입/지출 합계 아래                
  - **빈 상태에도 날짜 표시**               
                                                                       
  ### 2. 바텀시트 사이즈/위치 조정                                     
  - **최대 높이**: `max-h-[calc(100dvh-89px)]` →  `max-h-[calc(100dvh-113px)]`            
  - **X 버튼 위치**: `top-7.5` → `top-3.5`      
                                                                       
  ### 3. 감정 아이콘 표시                                              
  - 각 지출 항목에 감정 SVG 아이콘 표시
  - 공통 `EmotionIcon` 컴포넌트 사용                          
                                              
  ### 4. Mock 데이터 확장                                              
  - `CalendarExpenseItem` 에 `emotions?: string[]` 필드 추가           
  - 모든 일별 항목에 감정 데이터 추가                                                          
                                                                       
  ## 이슈 요청사항 반영                                                
                                                                       
  - [x] 달력에서 오늘 날짜 클릭 시 바텀시트에 날짜 표시                
  - [x] 지출 기록 없는 빈 상태 바텀시트에도 날짜 표시