### PR TITLE
[FIX] 가계부 수입지출 페이지 UI 수정

### DIFF
--- a/src/shared/ui/record/KeyBoardUserExperience.tsx
+++ b/src/shared/ui/record/KeyBoardUserExperience.tsx
@@ -22,12 +22,12 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
   };
 
   return (
-    <div className={'flex'}>
+    <div className={'flex pt-13.5'}>
       <div className={'key__pad grid grid-cols-3'}>
         <button
           onClick={() => handleNumberClick('1')}
           className={
-            'flex h-25 w-25 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
+            'flex h-23.75 w-24.5 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
           }
         >
           1
@@ -35,7 +35,7 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
         <button
           onClick={() => handleNumberClick('2')}
           className={
-            'flex h-25 w-25 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
+            'flex h-23.75 w-24.5 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
           }
         >
           2
@@ -43,7 +43,7 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
         <button
           onClick={() => handleNumberClick('3')}
           className={
-            'flex h-25 w-25 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
+            'flex h-23.75 w-24.5 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
           }
         >
           3
@@ -51,7 +51,7 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
         <button
           onClick={() => handleNumberClick('4')}
           className={
-            'flex h-25 w-25 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
+            'flex h-23.75 w-24.5 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
           }
         >
           4
@@ -59,7 +59,7 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
         <button
           onClick={() => handleNumberClick('5')}
           className={
-            'flex h-25 w-25 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
+            'flex h-23.75 w-24.5 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
           }
         >
           5
@@ -67,7 +67,7 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
         <button
           onClick={() => handleNumberClick('6')}
           className={
-            'flex h-25 w-25 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
+            'flex h-23.75 w-24.5 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
           }
         >
           6
@@ -75,7 +75,7 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
         <button
           onClick={() => handleNumberClick('7')}
           className={
-            'flex h-25 w-25 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
+            'flex h-23.75 w-24.5 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
           }
         >
           7
@@ -83,7 +83,7 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
         <button
           onClick={() => handleNumberClick('8')}
           className={
-            'flex h-25 w-25 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
+            'flex h-23.75 w-24.5 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
           }
         >
           8
@@ -91,7 +91,7 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
         <button
           onClick={() => handleNumberClick('9')}
           className={
-            'flex h-25 w-25 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
+            'flex h-23.75 w-24.5 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
           }
         >
           9
@@ -99,7 +99,7 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
         <button
           onClick={() => handleNumberClick('0')}
           className={
-            'flex h-25 w-25 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
+            'flex h-23.75 w-24.5 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
           }
         >
           0
@@ -107,7 +107,7 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
         <button
           onClick={() => handleDecimalClick(',00')}
           className={
-            'flex h-25 w-25 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
+            'flex h-23.75 w-24.5 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
           }
         >
           ,00
@@ -115,7 +115,7 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
         <button
           onClick={() => handleDecimalClick(',000')}
           className={
-            'flex h-25 w-25 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
+            'flex h-23.75 w-24.5 cursor-pointer items-center justify-center hover:bg-[#13278a] hover:text-white'
           }
         >
           ,000
@@ -147,12 +147,13 @@ export default function KeyBoardUserExperience({ changeAmount } : { changeAmount
           <Image src={'/svg/multiply.svg'} alt={'multiply'} width={24} height={24} />
         </button>
         <button
-          onClick={handleEquals}
-          className={'flex w-full flex-1 items-center justify-center bg-[#13278a] font-bold text-white hover:bg-[#0f1e5f]'}
+          onClick={() => handleOperation('/')}
+          className={'flex w-full flex-1 items-center justify-center hover:bg-gray-100'}
         >
-          =
+          <Image src={'/svg/division.svg'} alt={'division'} width={24} height={24} />
         </button>
       </div>
+      <button onClick={handleEquals} className={"absolute top-0 left-0 right-0 h-13.5 bg-[#13278a] text-white cursor-pointer"}>확인</button>
     </div>
   );
 }

--- a/src/widgets/record/RecordContent.tsx
+++ b/src/widgets/record/RecordContent.tsx
@@ -187,9 +187,9 @@ export default function RecordContent() {
   const getDisplayAmount = (): number => {
     if (!amountInput) return 0;
     try {
-      // 전체 식을 계산
+      const normalized = amountInput.replace(/,00/g, '.00').replace(/,000/g, '.000');
       // eslint-disable-next-line no-eval
-      const result = eval(amountInput);
+      const result = eval(normalized);
       return Math.round((result || 0) * 100) / 100;
     } catch {
       // 에러 시 마지막 숫자 반환
@@ -214,8 +214,11 @@ export default function RecordContent() {
         if (value === 'backspace') {
           result = prev.slice(0, -1);
         } else if (value === '+' || value === '-' || value === '*' || value === '/') {
-          if (!/[+\-*/]$/.test(result)) {
-            result = prev + value;
+          if (!/[+\-*/]$/.test(result) && result !== '') {
+            const calculated = calculateExpression(result);
+            result = calculated.toString() + value;
+          } else if (result === '') {
+            result = '0' + value;
           }
         } else if (value === ',00' || value === ',000') {
           const zeros = value === ',00' ? '00' : '000';
@@ -755,23 +758,24 @@ export default function RecordContent() {
 
       {/* Save Button */}
       <div className="fixed right-0 bottom-0 left-0 mx-auto max-w-md border-t border-gray-200 bg-white px-6 py-4">
-        <Button
-          onClick={() => {
-            if (isAssetMode) {
-              console.log('Asset saved:', record);
-            } else {
-              console.log('Record saved:', record);
+        {!isAmountEditing &&
+          <Button
+            onClick={() => {
+              if (isAssetMode) {
+                console.log('Asset saved:', record);
+              } else {
+                console.log('Record saved:', record);
+              }
+            }}
+            disabled={
+              isAssetMode
+                ? record.category === ''
+                : record.category === '' || (record.type === 'expense' && record.paymentMethod === '')
             }
-          }}
-          disabled={
-            isAssetMode
-              ? record.category === ''
-              : record.category === '' || (record.type === 'expense' && record.paymentMethod === '')
-          }
-          size="lg"
-        >
+            size="lg"
+          >
           저장
-        </Button>
+        </Button>}
         {isAmountEditing && <KeyBoardUserExperience changeAmount={handleAmountChange} />}
       </div>
     </div>

--- a/src/widgets/record/RecordContent.tsx
+++ b/src/widgets/record/RecordContent.tsx
@@ -133,7 +133,7 @@ export default function RecordContent() {
   const selectedDate = searchParams?.get('date') || today;
   const typeParam = searchParams?.get('type');
   const isAssetMode = typeParam === 'asset';
-  const initialType: 'income' | 'expense' = typeParam === 'expense' ? 'expense' : 'income';
+  const initialType: 'income' | 'expense' = typeParam === 'income' ? 'income' : 'expense';
 
   const [record, setRecord] = useState<RecordState>({
     amount: 0,
@@ -159,6 +159,7 @@ export default function RecordContent() {
   const [memoInput, setMemoInput] = useState('');
   const [tempTags, setTempTags] = useState<string[]>([]);
   const [tempMemo, setTempMemo] = useState('');
+  const [isDateSelected, setIsDateSelected] = useState(false);
 
   const [amountInput, setAmountInput] = useState('');
   const [isAmountEditing, setIsAmountEditing] = useState(false);
@@ -281,6 +282,7 @@ export default function RecordContent() {
       date: tempDate,
     }));
     setIsDateOpen(false);
+    setIsDateSelected(true);
   };
 
   const handleSituationSave = () => {
@@ -334,15 +336,6 @@ export default function RecordContent() {
       });
     }
 
-    const remainingDays = 42 - days.length;
-    for (let i = 1; i <= remainingDays; i++) {
-      days.push({
-        day: i,
-        isCurrentMonth: false,
-        date: `${year}-${String(month + 1).padStart(2, '0')}-${String(i).padStart(2, '0')}`,
-      });
-    }
-
     return days;
   };
 
@@ -356,7 +349,7 @@ export default function RecordContent() {
         <div className="mb-1">
           <div className="flex items-center gap-2">
             <>
-              <h2 className="pb-4 text-2xl font-bold text-gray-800">
+              <h2 className={cn('pb-4 text-2xl font-bold', record.type === 'expense' && (isAmountEditing ? getDisplayAmount() : record.amount) !== 0 ? 'text-red-600' : 'text-gray-800')}>
                 {isAmountEditing ? getDisplayAmount().toLocaleString() : record.amount.toLocaleString()}원
               </h2>
               <button
@@ -420,7 +413,7 @@ export default function RecordContent() {
         {!isAssetMode && (
           <SelectField
             label="날짜"
-            value={formatDateDisplay(record.date)}
+            value={isDateSelected ? formatDateDisplay(record.date) : ''}
             placeholder="날짜를 선택하세요"
             onClick={() => {
               setTempDate(record.date);
@@ -508,7 +501,7 @@ export default function RecordContent() {
               <Image src={'/svg/icon_arrow_left_fill.svg'} alt={'left'} width={20} height={20} />
             </button>
             <h3 className="px-3 text-lg font-semibold">
-              {calendarMonth.year}년 {calendarMonth.month}월
+              {calendarMonth.year === 2026 ? `${calendarMonth.month}월` : `${calendarMonth.year}년 ${calendarMonth.month}월`}
             </h3>
             <button
               onClick={() => {
@@ -518,11 +511,20 @@ export default function RecordContent() {
                   setCalendarMonth({ ...calendarMonth, month: calendarMonth.month + 1 });
                 }
               }}
-              className="cursor-pointer text-gray-500 hover:text-gray-700"
+              disabled={
+                calendarMonth.year === new Date(today).getFullYear() &&
+                calendarMonth.month === new Date(today).getMonth() + 1
+              }
+              className={cn(
+                calendarMonth.year === new Date(today).getFullYear() &&
+                calendarMonth.month === new Date(today).getMonth() + 1
+                  ? 'cursor-not-allowed text-gray-300 opacity-45'
+                  : 'cursor-pointer text-gray-500 hover:text-gray-700'
+              )}
             >
               <Image
                 src={'/svg/icon_arrow_left_fill.svg'}
-                alt={'left'}
+                alt={'right'}
                 width={20}
                 height={20}
                 className={'rotate-180'}
@@ -664,7 +666,7 @@ export default function RecordContent() {
             setSelectedEmotion('');
           }}
           onSave={handleEmotionSave}
-          isSaveDisabled={selectedEmotion === ''}
+          isSaveDisabled={false}
         >
           <div className="space-y-6">
             {EMOTIONS.map((group) => (
@@ -720,7 +722,7 @@ export default function RecordContent() {
           title="상황 태그 · 메모를 입력해주세요"
           onClose={() => setIsSituationOpen(false)}
           onSave={handleSituationSave}
-          isSaveDisabled={tempTags.length === 0 && tempMemo.trim() === ''}
+          isSaveDisabled={false}
         >
           <div className="space-y-6">
             <div>


### PR DESCRIPTION
# 수정사항

- 계산기 부분 UI 구성 및 기능 수정

- 날짜 부분 선택하지 않았을 경우 회색 텍스트로 표현

- 날짜 부분 캘린더 현재 달보다 뒷부분 가지 않게 예방책

- 날짜 부분 2026년 이전은 yyyy-mm-dd 형태로 구성

- 지출 부분에서 0원이 아닐 경우, 빨간색 텍스트로 표현