### PR TITLE
[FIX] 빌드 오류 수정

### DIFF
--- a/src/shared/hooks/useClickOutside.ts
+++ b/src/shared/hooks/useClickOutside.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef, RefObject } from 'react';
 
 export function useClickOutside<T extends HTMLElement>(
   callback: () => void
-): RefObject<T> {
+): RefObject<T | null> {
   const ref = useRef<T>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## 작업 개요                                                                                                 
  Vercel 배포를 위한 TypeScript 빌드 에러를 수정

  ## 원인                               
  `useRef<T>(null)`이 반환하는 실제 타입은 `RefObject<T | null>`이지만, 함수 반환 타입을 `RefObject<T>`로      
  명시하여 타입 불일치 발생.                                                                                   
                                                                                                               
  ## 해결                                                                                                      
  `useClickOutside` 훅의 반환 타입을 `RefObject<T | null>`로 수정.