### PR TITLE
[FIX] 회고 페이지 UI 수정

### DIFF
--- a/src/app/BackgroundProvider.tsx
+++ b/src/app/BackgroundProvider.tsx
@@ -11,13 +11,15 @@ export default function BackgroundProvider({ children }: { children: React.React
   return (
     <div
       className={cn(
-        'mx-auto flex min-h-screen max-w-md flex-col',
+        'min-h-screen w-full',
         isHomePage
           ? 'bg-linear-to-b from-[#ecf2fb] to-[#f3f8ff]' :
           isLoginPage ? 'bg-[#13278a]' : 'bg-white'
       )}
     >
-      {children}
+      <div className="mx-auto flex min-h-screen w-full max-w-md flex-col">
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/app/retro/page.tsx
+++ b/src/app/retro/page.tsx
@@ -16,7 +16,7 @@ export default function RetroPage() {
   const hasData = totalExpense > 0;
 
   return (
-    <div className="flex flex-1 flex-col">
+    <div className="flex min-h-0 flex-1 flex-col bg-white">
       <PageHeader title="회고하기" backHref="/" />
 
       <div className="px-4 pt-5">
@@ -28,7 +28,7 @@ export default function RetroPage() {
         </p>
       </div>
 
-      <div className="flex flex-1 items-start justify-center px-4 pt-5">
+      <div className="flex flex-1 items-start justify-center px-4 pt-5 pb-6">
         {hasData ? (
           <RetroMain
             totalExpense={totalExpense}
@@ -42,7 +42,7 @@ export default function RetroPage() {
         )}
       </div>
 
-      <div className="flex w-full items-center justify-center bg-white px-4 pt-6 pb-12.75">
+      <div className="flex w-full items-center justify-center bg-white px-4 pt-6 pb-9">
         <button
           onClick={() => router.push(hasData ? '/retro/survey' : '/record?type=expense')}
           className="h-13.5 w-full rounded-[10px] bg-[#13278A] text-[20px] font-semibold leading-normal tracking-[-0.5px] text-white transition-colors hover:bg-[#0F1F6E]"

--- a/src/app/retro/result/page.tsx
+++ b/src/app/retro/result/page.tsx
@@ -30,7 +30,7 @@ export default function RetroResultPage() {
         closeHref="/retro"
       />
 
-      <div className="flex flex-col gap-10 pb-25 pl-3.75 pr-4 pt-5">
+      <div className="flex flex-col gap-10 px-4 pt-5 pb-25">
         {/* 섹션 1: 타이틀 + 결과 카드 */}
         <div className="flex flex-col gap-5">
           {/* 타이틀 */}
@@ -42,7 +42,7 @@ export default function RetroResultPage() {
 
           {/* 결과 요약 카드 */}
           <div
-            className="flex h-30 w-89.75 flex-col gap-1.5 rounded-xl p-4"
+            className="flex h-30 w-full flex-col gap-1.5 rounded-xl p-4"
             style={{
               background:
                 'linear-gradient(98.51deg, #F7F8FA -1.34%, #ECF2FC 70.89%, #D8E8FF 119.81%) padding-box, linear-gradient(98.51deg, #6B9CE5 0%, #13278A 100%) border-box',
@@ -93,7 +93,7 @@ export default function RetroResultPage() {
               이런 점을 바꿔보면 어떨까요?
             </p>
           </div>
-          <div className="h-30 w-89.75 rounded-xl bg-[#F7F8FA] p-4">
+          <div className="h-30 w-full rounded-xl bg-[#F7F8FA] p-4">
             <p className="whitespace-pre-line text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#27282C]">
               {resultData.feedback.message}
             </p>
@@ -108,7 +108,7 @@ export default function RetroResultPage() {
               {resultData.feedback.actionTitle}
             </p>
           </div>
-          <div className="flex h-30 w-89.75 flex-col gap-3 rounded-xl bg-[#F7F8FA] p-4">
+          <div className="flex h-30 w-full flex-col gap-3 rounded-xl bg-[#F7F8FA] p-4">
             {resultData.feedback.actions.map((action) => (
               <div key={action} className="flex items-center gap-1.5">
                 <span className="flex size-3.75 shrink-0 items-center justify-center rounded-full bg-[#13278A]">

--- a/src/app/retro/survey/page.tsx
+++ b/src/app/retro/survey/page.tsx
@@ -150,7 +150,7 @@ export default function RetroSurveyPage() {
         </div>
       </div>
 
-      <div className="fixed bottom-0 left-1/2 flex w-full max-w-md -translate-x-1/2 items-center justify-center bg-white pt-6 pb-12.75 pl-4.25 pr-3.75">
+      <div className="fixed bottom-0 left-1/2 flex w-full max-w-97.5 -translate-x-1/2 items-center justify-center bg-white px-4 pt-6 pb-9">
         <button
           onClick={handleSubmit}
           className={`h-13.5 w-full rounded-[10px] text-[20px] font-semibold ${

--- a/src/app/retro/survey/page.tsx
+++ b/src/app/retro/survey/page.tsx
@@ -150,7 +150,7 @@ export default function RetroSurveyPage() {
         </div>
       </div>
 
-      <div className="fixed bottom-0 left-1/2 flex w-full max-w-97.5 -translate-x-1/2 items-center justify-center bg-white px-4 pt-6 pb-9">
+      <div className="fixed bottom-0 left-1/2 flex w-full max-w-md -translate-x-1/2 items-center justify-center bg-white px-4 pt-6 pb-9">
         <button
           onClick={handleSubmit}
           className={`h-13.5 w-full rounded-[10px] text-[20px] font-semibold ${

--- a/src/shared/constants/retroMockData.ts
+++ b/src/shared/constants/retroMockData.ts
@@ -7,8 +7,8 @@ export const retroMockData = {
     { name: '식비', amount: 42000, ratio: 80 },
   ],
   emotions: [
-    { name: '우울함', emoji: '😔' },
-    { name: '피곤함', emoji: '😩' },
-    { name: '스트레스', emoji: '😤' },
+    { name: '우울함' },
+    { name: '피곤함' },
+    { name: '스트레스' },
   ],
 };

--- a/src/widgets/retro/RetroEmpty.tsx
+++ b/src/widgets/retro/RetroEmpty.tsx
@@ -1,6 +1,6 @@
 export default function RetroEmpty() {
   return (
-    <div className="flex h-90 w-89.5 items-center justify-center rounded-[12px] bg-[#F7F8FA] p-2.5">
+    <div className="flex h-90 w-full items-center justify-center rounded-[12px] bg-[#F7F8FA] p-2.5">
       <div className="flex flex-col items-center">
         <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#474C52]">
           지출 기록이 아직 없어요

--- a/src/widgets/retro/RetroMain.tsx
+++ b/src/widgets/retro/RetroMain.tsx
@@ -41,7 +41,7 @@ export default function RetroMain({
   return (
     <div className="flex w-full flex-col gap-5">
 
-      <div className="relative flex h-90 w-89.5 flex-col items-center rounded-[12px] bg-[#F7F8FA]">
+      <div className="relative flex h-90 w-full flex-col items-center rounded-[12px] bg-[#F7F8FA] px-5">
         <div className="mt-7.5 flex flex-col items-center gap-0.5">
           <p className="text-[18px] font-bold text-[#1C1D1F]">
             오늘은 {topCategory}에 가장 많이 지출했어요
@@ -72,7 +72,7 @@ export default function RetroMain({
 
         <button
           onClick={handleDetailClick}
-          className="absolute bottom-4 mx-auto w-78.5 rounded-lg bg-[#DEE8F7] px-14 py-2.5"
+          className="absolute right-4 bottom-4 left-4 rounded-lg bg-[#DEE8F7] px-14 py-2.5"
         >
           <p className="text-center text-[16px] font-semibold text-[#13278A]">
             지출 상세 내역
@@ -80,7 +80,7 @@ export default function RetroMain({
         </button>
       </div>
 
-      <div className="overflow-hidden" ref={emblaRef}>
+      <div className="-mx-4 overflow-hidden" ref={emblaRef}>
         <div className="flex gap-1.5">
           {emotions.map((emotion) => (
             <div

--- a/src/widgets/retro/RetroMain.tsx
+++ b/src/widgets/retro/RetroMain.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import useEmblaCarousel from 'embla-carousel-react';
+import EmotionIcon from '@/shared/ui/EmotionIcon';
 
 interface ExpenseCategory {
   name: string;
@@ -11,7 +12,6 @@ interface ExpenseCategory {
 
 interface Emotion {
   name: string;
-  emoji: string;
 }
 
 interface RetroMainProps {
@@ -87,12 +87,12 @@ export default function RetroMain({
               key={emotion.name}
               className="flex h-21.25 w-37 shrink-0 flex-col items-center justify-center rounded-[12px] bg-[#F7F8FA] px-4 py-3.5"
             >
-              <p className="text-[14px] font-medium text-[#73787E]">
+              <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#73787E]">
                 오늘의 소비 감정
               </p>
               <div className="mt-1.5 flex items-center gap-1.5">
-                <span className="text-[25px]">{emotion.emoji}</span>
-                <p className="text-[20px] font-semibold text-[#1C1D1F]">
+                <EmotionIcon name={emotion.name} size={25} />
+                <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#1C1D1F]">
                   {emotion.name}
                 </p>
               </div>


### PR DESCRIPTION
  ## 작업 내용                                                          
                                                                        
  회고 페이지(/retro, /retro/survey, /retro/result)의 모바일 반응형 깨짐 수정 및 감정 이모지 SVG 적용.                                        
                                                                        
  ### 1. 반응형 레이아웃 수정                                           
                                        
  - 고정 픽셀 너비 `w-89.5`(358px), `w-89.75`(359px) → `w-full`로 교체  
  - 모든 모바일 기기에서 부모 컨테이너 너비에 자동 맞춤                 
  - 비대칭 padding(`pl-3.75 pr-4`) → `px-4` 균일화                      
                                                                        
  ### 2. BackgroundProvider 구조 개선                                   
                                                                        
  - 외부(`w-full` + 페이지별 배경) + 내부(`max-w-md` 콘텐츠) 2단 구조로 
  분리                                                                  
  - 데스크탑/태블릿 폭에서 노출되던 회색 띠(`bg-gray-50`) 제거          
  - 페이지별 배경(white / gradient / navy)이 뷰포트 끝까지 확장         
                                                                        
  ### 3. 감정 이모지 SVG 적용                                           
                                                                        
  - 유니코드 이모지 → `EmotionIcon` 컴포넌트 사용 (`/svg/emo/*.svg`)    
  - 매핑은 기존 `emotionMap.ts` 활용                                    
                                                                        
  ### 4. 캐러셀 개선                                                    
                                                                        
  - 회고 메인 페이지의 감정 캐러셀이 페이지 padding(`px-4`)을 넘어 max-w-md 끝까지 확장                  