### PR TITLE
[FEAT] 캘린더 수입 기능 구현

### DIFF
--- a/src/entities/income/api/income-api.ts
+++ b/src/entities/income/api/income-api.ts
@@ -1,0 +1,20 @@
+import { apiClient } from '@/shared/api/api-instance';
+import { Income } from '@/entities/income/model/income-schema';
+
+export function getMonthlyIncomesApi({
+  year,
+  month,
+  token,
+}: {
+  year: number;
+  month: number;
+  token: string;
+}): Promise<Income[]> {
+  return apiClient<Income[]>(
+    `/api/v1/incomes/monthly?year=${year}&month=${month}`,
+    {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+}

--- a/src/entities/income/api/income-queries.ts
+++ b/src/entities/income/api/income-queries.ts
@@ -1,0 +1,12 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getMonthlyIncomesApi } from '@/entities/income/api/income-api';
+
+export const incomeQueries = {
+  all: () => ['income'] as const,
+  monthly: (token: string, year: number, month: number) =>
+    queryOptions({
+      queryKey: [...incomeQueries.all(), 'monthly', year, month],
+      queryFn: () => getMonthlyIncomesApi({ year, month, token }),
+      staleTime: 1000 * 60,
+    }),
+};

--- a/src/entities/income/index.ts
+++ b/src/entities/income/index.ts
@@ -1,0 +1,3 @@
+export { getMonthlyIncomesApi } from './api/income-api';
+export { incomeQueries } from './api/income-queries';
+export { IncomeSchema, type Income } from './model/income-schema';

--- a/src/entities/income/model/income-schema.ts
+++ b/src/entities/income/model/income-schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const IncomeSchema = z.object({
+  userId: z.number(),
+  amount: z.number(),
+  incomeCategoryId: z.number(),
+  incomeDate: z.string(),
+  memo: z.string().nullable(),
+});
+
+export type Income = z.infer<typeof IncomeSchema>;

--- a/src/entities/master-data/index.ts
+++ b/src/entities/master-data/index.ts
@@ -6,5 +6,6 @@ export {
   type Category,
   type Emotion,
   type SituationTag,
+  type PaymentMethod,
 } from './model/master-data-schema';
 export { useMasterData } from './model/useMasterData';

--- a/src/entities/master-data/model/master-data-schema.ts
+++ b/src/entities/master-data/model/master-data-schema.ts
@@ -12,8 +12,8 @@ const CategoryGroupSchema = z.object({
 });
 
 const EmotionSchema = z.object({
-  id: z.number(),
-  name: z.string(),
+  emotionId: z.number(),
+  emotionName: z.string(),
 });
 
 const EmotionGroupSchema = z.object({
@@ -23,6 +23,11 @@ const EmotionGroupSchema = z.object({
 });
 
 const SituationTagSchema = z.object({
+  situationTagId: z.number(),
+  situationName: z.string(),
+});
+
+const PaymentMethodSchema = z.object({
   id: z.number(),
   name: z.string(),
 });
@@ -31,9 +36,11 @@ export const MasterDataSchema = z.object({
   categoryGroups: z.array(CategoryGroupSchema),
   emotionGroups: z.array(EmotionGroupSchema),
   situationTags: z.array(SituationTagSchema),
+  paymentMethods: z.array(PaymentMethodSchema),
 });
 
 export type MasterData = z.infer<typeof MasterDataSchema>;
 export type Category = z.infer<typeof CategorySchema>;
 export type Emotion = z.infer<typeof EmotionSchema>;
 export type SituationTag = z.infer<typeof SituationTagSchema>;
+export type PaymentMethod = z.infer<typeof PaymentMethodSchema>;

--- a/src/entities/master-data/model/useMasterData.ts
+++ b/src/entities/master-data/model/useMasterData.ts
@@ -29,6 +29,11 @@ interface SituationTag {
   id: number;
 }
 
+interface PaymentMethod {
+  label: string;
+  id: number;
+}
+
 function buildExpenseCategories(masterData?: MasterData): ExpenseCategory[] {
   if (!masterData?.categoryGroups) return [];
 
@@ -48,9 +53,9 @@ function buildEmotions(masterData?: MasterData): Emotion[] {
   return masterData.emotionGroups.map((group) => ({
     group: group.name,
     items: group.emotions.map((emotion) => ({
-      label: emotion.name,
-      emoji: EMOTION_SVG_MAP[emotion.id] || '',
-      id: emotion.id,
+      label: emotion.emotionName,
+      emoji: EMOTION_SVG_MAP[emotion.emotionId] || '',
+      id: emotion.emotionId,
     })),
   }));
 }
@@ -59,8 +64,17 @@ function buildSituationTags(masterData?: MasterData): SituationTag[] {
   if (!masterData?.situationTags) return [];
 
   return masterData.situationTags.map((tag) => ({
-    label: tag.name,
-    id: tag.id,
+    label: tag.situationName,
+    id: tag.situationTagId,
+  }));
+}
+
+function buildPaymentMethods(masterData?: MasterData): PaymentMethod[] {
+  if (!masterData?.paymentMethods) return [];
+
+  return masterData.paymentMethods.map((method) => ({
+    label: method.name,
+    id: method.id,
   }));
 }
 
@@ -85,10 +99,16 @@ export function useMasterData() {
     [masterData],
   );
 
+  const paymentMethods = useMemo(
+    () => buildPaymentMethods(masterData),
+    [masterData],
+  );
+
   return {
     expenseCategories,
     emotions,
     situationTags,
+    paymentMethods,
     masterData,
     isLoading,
   };

--- a/src/widgets/calendar/CalendarContent.tsx
+++ b/src/widgets/calendar/CalendarContent.tsx
@@ -12,13 +12,6 @@ import CalendarGrid from '@/widgets/calendar/CalendarGrid';
 import DateBottomSheet from '@/widgets/calendar/DateBottomSheet';
 import PageHeader from '@/shared/ui/PageHeader';
 
-const PAYMENT_METHOD_NAMES: Record<number, string> = {
-  1: '카드',
-  2: '현금',
-  3: '계좌',
-  4: '기타',
-};
-
 const INCOME_CATEGORY_NAMES: Record<number, string> = {
   1: '급여',
   2: '용돈',
@@ -32,16 +25,22 @@ function buildLookups(masterData?: MasterData) {
   const categoryMap = new Map<number, string>();
   const emotionMap = new Map<number, string>();
   const situationMap = new Map<number, string>();
+  const paymentMethodMap = new Map<number, string>();
 
   masterData?.categoryGroups.forEach((g) =>
     g.categories.forEach((c) => categoryMap.set(c.id, c.name)),
   );
   masterData?.emotionGroups.forEach((g) =>
-    g.emotions.forEach((e) => emotionMap.set(e.id, e.name)),
+    g.emotions.forEach((e) => emotionMap.set(e.emotionId, e.emotionName)),
   );
-  masterData?.situationTags.forEach((s) => situationMap.set(s.id, s.name));
+  masterData?.situationTags.forEach((s) =>
+    situationMap.set(s.situationTagId, s.situationName),
+  );
+  masterData?.paymentMethods.forEach((p) =>
+    paymentMethodMap.set(p.id, p.name),
+  );
 
-  return { categoryMap, emotionMap, situationMap };
+  return { categoryMap, emotionMap, situationMap, paymentMethodMap };
 }
 
 export default function CalendarContent() {
@@ -69,7 +68,7 @@ export default function CalendarContent() {
     enabled: !!token,
   });
 
-  const { categoryMap, emotionMap, situationMap } = useMemo(
+  const { categoryMap, emotionMap, situationMap, paymentMethodMap } = useMemo(
     () => buildLookups(masterData),
     [masterData],
   );
@@ -112,7 +111,7 @@ export default function CalendarContent() {
         .map((id) => situationMap.get(id))
         .filter((n): n is string => !!n),
       amount: e.amount,
-      paymentMethod: PAYMENT_METHOD_NAMES[e.paymentMethodId] ?? '',
+      paymentMethod: paymentMethodMap.get(e.paymentMethodId) ?? '',
       memo: e.memo ?? undefined,
       emotions: e.emotionIds
         .map((id) => emotionMap.get(id))
@@ -126,7 +125,15 @@ export default function CalendarContent() {
     const expense = dayExpenses.reduce((acc, e) => acc + e.amount, 0);
     const income = dayIncomes.reduce((acc, i) => acc + i.amount, 0);
     return { income, expense, expenseItems, incomeItems };
-  }, [expenses, incomes, selectedDay, categoryMap, emotionMap, situationMap]);
+  }, [
+    expenses,
+    incomes,
+    selectedDay,
+    categoryMap,
+    emotionMap,
+    situationMap,
+    paymentMethodMap,
+  ]);
 
   const handlePrevMonth = () => {
     if (month === 0) {

--- a/src/widgets/calendar/CalendarContent.tsx
+++ b/src/widgets/calendar/CalendarContent.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { useToken } from '@/shared/store';
 import { expenseQueries } from '@/entities/expense';
+import { incomeQueries } from '@/entities/income';
 import { masterDataQueries, type MasterData } from '@/entities/master-data';
 import CalendarHeader from '@/widgets/calendar/CalendarHeader';
 import CalendarGrid from '@/widgets/calendar/CalendarGrid';
@@ -16,6 +17,15 @@ const PAYMENT_METHOD_NAMES: Record<number, string> = {
   2: '현금',
   3: '계좌',
   4: '기타',
+};
+
+const INCOME_CATEGORY_NAMES: Record<number, string> = {
+  1: '급여',
+  2: '용돈',
+  3: '부수입',
+  4: '상여금',
+  5: '금융수입',
+  6: '기타',
 };
 
 function buildLookups(masterData?: MasterData) {
@@ -49,6 +59,11 @@ export default function CalendarContent() {
     enabled: !!token,
   });
 
+  const { data: incomes } = useQuery({
+    ...incomeQueries.monthly(token || '', year, month + 1),
+    enabled: !!token,
+  });
+
   const { data: masterData } = useQuery({
     ...masterDataQueries.data(token || ''),
     enabled: !!token,
@@ -60,28 +75,36 @@ export default function CalendarContent() {
   );
 
   const dailyAmounts = useMemo(() => {
-    const map: Record<number, { expense: number }> = {};
+    const map: Record<number, { income: number; expense: number }> = {};
     (expenses ?? []).forEach((e) => {
       const day = Number(e.expenseDate.split('-')[2]);
-      const prev = map[day]?.expense ?? 0;
-      map[day] = { expense: prev + e.amount };
+      const prev = map[day] ?? { income: 0, expense: 0 };
+      map[day] = { ...prev, expense: prev.expense + e.amount };
+    });
+    (incomes ?? []).forEach((i) => {
+      const day = Number(i.incomeDate.split('-')[2]);
+      const prev = map[day] ?? { income: 0, expense: 0 };
+      map[day] = { ...prev, income: prev.income + i.amount };
     });
     return map;
-  }, [expenses]);
+  }, [expenses, incomes]);
 
   const monthlyTotals = useMemo(() => {
-    const income = 0;
+    const income = (incomes ?? []).reduce((acc, i) => acc + i.amount, 0);
     const expense = (expenses ?? []).reduce((acc, e) => acc + e.amount, 0);
     const balance = income - expense;
     return { income, expense, balance: balance || 0 };
-  }, [expenses]);
+  }, [expenses, incomes]);
 
   const dayData = useMemo(() => {
-    if (selectedDay == null || !expenses) {
+    if (selectedDay == null) {
       return { income: 0, expense: 0, expenseItems: [], incomeItems: [] };
     }
-    const dayExpenses = expenses.filter(
+    const dayExpenses = (expenses ?? []).filter(
       (e) => Number(e.expenseDate.split('-')[2]) === selectedDay,
+    );
+    const dayIncomes = (incomes ?? []).filter(
+      (i) => Number(i.incomeDate.split('-')[2]) === selectedDay,
     );
     const expenseItems = dayExpenses.map((e) => ({
       category: categoryMap.get(e.categoryId) ?? '',
@@ -95,9 +118,15 @@ export default function CalendarContent() {
         .map((id) => emotionMap.get(id))
         .filter((n): n is string => !!n),
     }));
+    const incomeItems = dayIncomes.map((i) => ({
+      category: INCOME_CATEGORY_NAMES[i.incomeCategoryId] ?? '',
+      amount: i.amount,
+      memo: i.memo ?? undefined,
+    }));
     const expense = dayExpenses.reduce((acc, e) => acc + e.amount, 0);
-    return { income: 0, expense, expenseItems, incomeItems: [] };
-  }, [expenses, selectedDay, categoryMap, emotionMap, situationMap]);
+    const income = dayIncomes.reduce((acc, i) => acc + i.amount, 0);
+    return { income, expense, expenseItems, incomeItems };
+  }, [expenses, incomes, selectedDay, categoryMap, emotionMap, situationMap]);
 
   const handlePrevMonth = () => {
     if (month === 0) {


### PR DESCRIPTION
## 작업 내용                                                                                                                               
                                                                                                                                             
  ### 캘린더 수입 API 연동                                                                                                                                                                                                     
  - `GET /api/v1/incomes/monthly` 연동                                          
  - 월별 헤더 합계, 일별 셀 +수입 표시, 바텀시트 수입 항목 매핑                                                                              
                                                                                
  ### 결제수단 마스터데이터 매핑                                                                                                             
  - 백엔드 master-data 응답에 `paymentMethods` 필드 추가됨에 맞춰 스키마 갱신   
  - `emotion`/`situationTag` 필드명 변경 반영 (`emotionId`/`emotionName`, `situationTagId`/`situationName`)                                  
  - `useMasterData`에 `paymentMethods` 노출                                                                                                  
  - `CalendarContent`의 `PAYMENT_METHOD_NAMES` 하드코딩 제거 → master-data 매핑으로 교체                                                     
                                                                                                                                             
  ## 알려진 이슈 (백엔드 후속 필요)                                                                                                          
  - **수입 카테고리 매핑 소스 부재**: master-data 응답에 `incomeCategoryGroups`누락. 임시로                                 
  `INCOME_CATEGORY_NAMES` 하드코딩으로 대응. 백엔드에 추가 요청 완료하여 추후 수정 예정