### PR TITLE
[FIX] 이슈 수정

### DIFF
--- a/src/entities/master-data/model/master-data-schema.ts
+++ b/src/entities/master-data/model/master-data-schema.ts
@@ -12,8 +12,8 @@ const CategoryGroupSchema = z.object({
 });
 
 const EmotionSchema = z.object({
-  emotionId: z.number(),
-  emotionName: z.string(),
+  id: z.number(),
+  name: z.string(),
 });
 
 const EmotionGroupSchema = z.object({
@@ -23,8 +23,8 @@ const EmotionGroupSchema = z.object({
 });
 
 const SituationTagSchema = z.object({
-  situationTagId: z.number(),
-  situationName: z.string(),
+  id: z.number(),
+  name: z.string(),
 });
 
 const PaymentMethodSchema = z.object({

--- a/src/entities/master-data/model/useMasterData.ts
+++ b/src/entities/master-data/model/useMasterData.ts
@@ -53,9 +53,9 @@ function buildEmotions(masterData?: MasterData): Emotion[] {
   return masterData.emotionGroups.map((group) => ({
     group: group.name,
     items: group.emotions.map((emotion) => ({
-      label: emotion.emotionName,
-      emoji: EMOTION_SVG_MAP[emotion.emotionId] || '',
-      id: emotion.emotionId,
+      label: emotion.name,
+      emoji: EMOTION_SVG_MAP[emotion.id] || '',
+      id: emotion.id,
     })),
   }));
 }
@@ -64,8 +64,8 @@ function buildSituationTags(masterData?: MasterData): SituationTag[] {
   if (!masterData?.situationTags) return [];
 
   return masterData.situationTags.map((tag) => ({
-    label: tag.situationName,
-    id: tag.situationTagId,
+    label: tag.name,
+    id: tag.id,
   }));
 }
 

--- a/src/entities/today-expenditure/model/useTodayExpend.ts
+++ b/src/entities/today-expenditure/model/useTodayExpend.ts
@@ -3,10 +3,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { todayExpendQueries } from '@/entities/today-expenditure/api/today-expend-queries';
 import { useMonthExpendStore } from '@/shared/store/month-expend-store';
+import { useToken } from '@/shared/store';
 import { useEffect, useRef } from 'react';
 
 export function useTodayExpend(year: number, month: number) {
   const prevMonthRef = useRef<string | null>(null);
+  const { getAccessToken } = useToken();
+  const accessToken = getAccessToken();
 
   const query = useQuery({
     ...todayExpendQueries.getTodayQueries(year, month),
@@ -23,6 +26,11 @@ export function useTodayExpend(year: number, month: number) {
     }
     prevMonthRef.current = currentMonth;
   }, [year, month, query]);
+
+  // 토큰이 변경될 때 refetch (로그아웃/로그인 시)
+  useEffect(() => {
+    query.refetch();
+  }, [accessToken, query]);
 
   const { setData } = useMonthExpendStore();
 

--- a/src/shared/ui/ConfirmModal.tsx
+++ b/src/shared/ui/ConfirmModal.tsx
@@ -33,10 +33,10 @@ export default function ConfirmModal({
       {type === 'loginCheck' || type === 'logoutCheck' ? (
         <div
           className={
-            'box__container__2 fixed top-1/2 right-0 left-0 z-60 mx-auto h-auto w-70 -translate-y-1/2 rounded-[10px] bg-white px-6 pt-8 pb-5'
+            'box__container__2 fixed top-1/2 right-0 left-0 z-60 mx-auto h-auto w-70.75 -translate-y-1/2 rounded-[10px] bg-white px-5.25 pt-12.25 pb-5'
           }
         >
-          <span className={'mb-4 block text-center text-[14px] font-bold'}>{title}</span>
+          <span className={'mb-1 block text-center text-[14px] font-bold'}>{title}</span>
           <span className={'text-ray-600 mb-8 block text-center text-[14px]'}>{secondary}</span>
           <div className={'button__wrapper flex flex-col gap-2'}>
             <button className={'rounded-[8px] bg-[#13278a] py-2 text-[14px] text-white'} onClick={onConfirm}>

--- a/src/shared/ui/SelectField.tsx
+++ b/src/shared/ui/SelectField.tsx
@@ -7,6 +7,7 @@ interface SelectFieldProps {
   value: React.ReactNode;
   placeholder: string;
   onClick: () => void;
+  isDefault?: boolean;
 }
 
 export default function SelectField({
@@ -14,6 +15,7 @@ export default function SelectField({
   value,
   placeholder,
   onClick,
+  isDefault = false,
 }: SelectFieldProps) {
   const hasValue = typeof value === 'string' ? value !== '' : !!value;
 
@@ -26,7 +28,9 @@ export default function SelectField({
       >
         {hasValue ? (
           typeof value === 'string' ? (
-            <span className="text-[17px] font-semibold tracking-[-0.025em] text-[#13278a] transition-colors">
+            <span className={`text-[17px] font-semibold tracking-[-0.025em] transition-colors ${
+              isDefault ? 'text-[#9fa4a8]' : 'text-[#13278a]'
+            }`}>
               {value}
             </span>
           ) : (

--- a/src/shared/ui/house-hold/TodayExpenseBox.tsx
+++ b/src/shared/ui/house-hold/TodayExpenseBox.tsx
@@ -197,13 +197,15 @@ export default function TodayExpenseBox() {
                       key={emoIdx}
                       className="inline-flex items-center gap-1.25 rounded-full bg-[#f0f4f5] px-2.5 py-0.75 text-[12px] font-medium tracking-[-0.025em] text-[#474c52]"
                     >
-                      <Image
-                        src={emotion.emoji}
-                        alt={emotion.label}
-                        width={14}
-                        height={14}
-                        loading="lazy"
-                      />
+                      {emotion.emoji && (
+                        <Image
+                          src={emotion.emoji}
+                          alt={emotion.label}
+                          width={14}
+                          height={14}
+                          loading="lazy"
+                        />
+                      )}
                       <span>{emotion.label}</span>
                     </span>
                   ))}

--- a/src/shared/ui/house-hold/TodayExpenseBox.tsx
+++ b/src/shared/ui/house-hold/TodayExpenseBox.tsx
@@ -18,7 +18,7 @@ const MIN_DATE = (() => {
 })();
 
 export default function TodayExpenseBox() {
-  const { emotions } = useMasterData();
+  const { emotions, expenseCategories } = useMasterData();
   const router = useRouter();
   const [selectedDate, setSelectedDate] = useState<Date>(TODAY);
   const { getUser } = useUser();
@@ -63,8 +63,12 @@ export default function TodayExpenseBox() {
 
     dailyExpenseList.forEach((expense) => {
       if (!categoryMap.has(expense.categoryId)) {
+        const categoryLabel = expenseCategories
+          .flatMap((g) => g.items)
+          .find((item) => item.id === expense.categoryId)?.label || '기타';
+
         categoryMap.set(expense.categoryId, {
-          name: expense.merchantName || '기타',
+          name: categoryLabel,
           amount: 0,
           emotions: [],
         });
@@ -87,7 +91,7 @@ export default function TodayExpenseBox() {
       totalAmount: dailyExpenseList.reduce((sum, item) => sum + item.amount, 0),
       categories: Array.from(categoryMap.values()),
     };
-  }, [dailyExpenseList]);
+  }, [dailyExpenseList, emotions, expenseCategories]);
 
   const formattedDate = useFormattedDate(selectedDate.toISOString(), {
     year: undefined,

--- a/src/widgets/export/ExportContent.tsx
+++ b/src/widgets/export/ExportContent.tsx
@@ -175,8 +175,13 @@ export default function ExportContent() {
           <SortButton sortType={sortType} onSortChange={setSortType} />
         </div>
 
+        {/* 날짜 라벨 */}
+        <p className="mb-4 text-[14px] font-semibold tracking-[-0.025em] text-gray-500">
+          {formattedDate}
+        </p>
+
         {totalAmount === 0 ? (
-          <div className="flex flex-col items-center justify-center py-20 text-center absolute top-1/2 left-1/2 -translate-y-1/2 -translate-x-1/2">
+          <div className="flex flex-col items-center justify-center py-20 text-center">
             <h3 className="mb-1 text-[18px] font-semibold tracking-[-0.025em] text-[#474c52]">
               지출 기록이 아직 없어요
             </h3>
@@ -186,11 +191,6 @@ export default function ExportContent() {
           </div>
         ) : (
           <div>
-            {/* 날짜 라벨 */}
-            <p className="mb-2.5 text-[14px] font-medium tracking-[-0.025em] text-[#474c52]">
-              {formattedDate}
-            </p>
-
             {/* 항목 리스트 */}
             <div className="flex flex-col gap-5">
               {expenses.map((expense) => (

--- a/src/widgets/export/ExportContent.tsx
+++ b/src/widgets/export/ExportContent.tsx
@@ -250,13 +250,15 @@ export default function ExportContent() {
                               <span className="h-3.5 w-px shrink-0 bg-[#e5e5e5]" />
                               <div className="flex items-center gap-1.5">
                                 {expense.emotions.map((emotion) => (
-                                  <Image
-                                    key={emotion.label}
-                                    src={emotion.emoji}
-                                    alt={emotion.label}
-                                    width={20}
-                                    height={20}
-                                  />
+                                  emotion.emoji && (
+                                    <Image
+                                      key={emotion.label}
+                                      src={emotion.emoji}
+                                      alt={emotion.label}
+                                      width={20}
+                                      height={20}
+                                    />
+                                  )
                                 ))}
                               </div>
                             </>

--- a/src/widgets/export/ExportContent.tsx
+++ b/src/widgets/export/ExportContent.tsx
@@ -170,13 +170,13 @@ export default function ExportContent() {
       </div>
 
       {/* 정렬 셀렉터 + 본문 */}
-      <div className="overflow-y-auto px-4 pt-5 pb-12">
+      <div className="overflow-y-auto px-4 pt-5 pb-12 h-118.5 relative">
         <div className="flex justify-end">
           <SortButton sortType={sortType} onSortChange={setSortType} />
         </div>
 
         {totalAmount === 0 ? (
-          <div className="flex flex-col items-center justify-center py-20 text-center">
+          <div className="flex flex-col items-center justify-center py-20 text-center absolute top-1/2 left-1/2 -translate-y-1/2 -translate-x-1/2">
             <h3 className="mb-1 text-[18px] font-semibold tracking-[-0.025em] text-[#474c52]">
               지출 기록이 아직 없어요
             </h3>

--- a/src/widgets/house-hold/HouseHoldWrapper.tsx
+++ b/src/widgets/house-hold/HouseHoldWrapper.tsx
@@ -17,12 +17,12 @@ export default function HouseHoldWrapper() {
           blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
         />
       </div>
-      <div className="absolute right-25.5 top-14 z-10">
+      <div className="absolute right-23 top-13.5 z-10">
         <Image
           src="/svg/free_log_chc_hand.png"
           alt="decoration hand"
-          width={44}
-          height={12}
+          width={64}
+          height={22}
           priority
           placeholder="blur"
           blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="

--- a/src/widgets/login/LoginContent.tsx
+++ b/src/widgets/login/LoginContent.tsx
@@ -38,7 +38,7 @@ export default function LoginContent() {
           <SocialLoginButton
             social={'google'}
             imageUrl={'/svg/google.svg'}
-            text={'구글로 로그인하기'}
+            text={'구글로 로그인'}
             color={'#ffffff'}
             textColor={'#000'}
             isPriority={true}

--- a/src/widgets/record/RecordContent.tsx
+++ b/src/widgets/record/RecordContent.tsx
@@ -539,8 +539,9 @@ export default function RecordContent() {
         {/* Date Section */}
         <SelectField
           label="날짜"
-          value={isDateSelected ? formatDateDisplay(record.date) : ''}
+          value={formatDateDisplay(record.date)}
           placeholder="날짜를 선택하세요"
+          isDefault={!isDateSelected}
           onClick={() => {
             setTempDate(record.date);
             setCalendarMonth(() => {

--- a/src/widgets/record/RecordContent.tsx
+++ b/src/widgets/record/RecordContent.tsx
@@ -844,7 +844,7 @@ export default function RecordContent() {
                           : 'border-[#e5e5e5] text-[#27282c]'
                       )}
                     >
-                      <Image src={item.emoji} alt={item.label} width={24} height={24} />
+                      {item.emoji && <Image src={item.emoji} alt={item.label} width={24} height={24} />}
                       <span>{item.label}</span>
                     </button>
                   ))}

--- a/src/widgets/record/RecordContent.tsx
+++ b/src/widgets/record/RecordContent.tsx
@@ -415,7 +415,7 @@ export default function RecordContent() {
 
   const isFormValid = () => {
     if (record.type === 'expense') {
-      return isDateSelected && record.paymentMethodId !== null && record.categoryId !== null;
+      return record.amount > 0 && isDateSelected && record.paymentMethodId !== null && record.categoryId !== null;
     }
     if (isAssetMode) {
       return isDateSelected && record.amount > 0 && record.categoryId !== null;

--- a/src/widgets/record/RecordContent.tsx
+++ b/src/widgets/record/RecordContent.tsx
@@ -464,7 +464,7 @@ export default function RecordContent() {
 
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-white" onClick={() => isAmountEditing && setIsAmountEditing(false)}>
       <PageHeader title={isEditMode ? '지출 수정' : isAssetMode ? '자산 추가' : '가계부'} />
 
       <div className="px-6 py-6 pb-40">
@@ -927,7 +927,7 @@ export default function RecordContent() {
       )}
 
       {/* Save Button */}
-      <div className="fixed right-0 bottom-0 left-0 mx-auto max-w-md bg-white">
+      <div className="fixed right-0 bottom-0 left-0 mx-auto max-w-md bg-white" onClick={(e) => e.stopPropagation()}>
         {!isAmountEditing && (
           <div className="px-4 pt-6 pb-12">
             <Button

--- a/src/widgets/report/ReportMonthCard.tsx
+++ b/src/widgets/report/ReportMonthCard.tsx
@@ -100,7 +100,7 @@ export default function ReportMonthCard({
 
           <button
             onClick={onExpenseDetailClick}
-            className="flex h-11 w-full items-center justify-center rounded-[8px] bg-white shadow-[0px_0px_4px_rgba(19,39,138,0.08)]"
+            className="flex h-13 w-full items-center justify-center rounded-[8px] bg-white shadow-[0px_0px_4px_rgba(19,39,138,0.08)]"
           >
             <span className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#27282C]">
               {isEmpty ? '지출 기록하기' : '이번 달 지출 확인하기'}


### PR DESCRIPTION
캐릭터 손 크기 맞출 것

로그인 팝업 전체적으로 디자인 수정

지출 기록이 아직 없어요 메시지 위치 수정 + 날짜 누락 추가

리포트 -> 지출 기록하기 패딩값 체크

0원 입력 시에도 저장이 되는 이슈

미로그인시, 로그인이나와야하는 팝업 위치 다시 설정 필요

지출 등록에서 오늘 날짜가 디폴트로 노출되어야 함

금액 입력 후 빈공간 클릭시 키패드가 없어지면 좋겠다.

지출등록시 감정선택 /상황 태그 바텀시트 올라올때, 감정 아이콘,상황태그가 안보임

‘구글로 로그인하기’ > ‘구글로 로그인’ 으로 변경

지출 등록하고 로그아웃 후 재로그인 시 적용 바로 안되는 문제