### PR TITLE
[FEAT] 로딩 스켈레톤 적용

### DIFF
--- a/src/app/retro/survey/page.tsx
+++ b/src/app/retro/survey/page.tsx
@@ -8,6 +8,7 @@ import { reviewQueries, upsertReviewApi } from '@/entities/review';
 import ChipSelect from '@/widgets/retro/ChipSelect';
 import ListSelect from '@/widgets/retro/ListSelect';
 import PageHeader from '@/shared/ui/PageHeader';
+import Skeleton from '@/shared/ui/Skeleton';
 
 function todayDateString(): string {
   const d = new Date();
@@ -70,8 +71,11 @@ export default function RetroSurveyPage() {
     return (
       <div className="flex flex-1 flex-col">
         <PageHeader title="회고하기" backHref="/retro" />
-        <div className="flex flex-1 items-center justify-center py-20">
-          <p className="text-[14px] text-[#9FA4A8]">불러오는 중...</p>
+        <div className="flex flex-col gap-6 px-4 pt-5 pb-36">
+          <Skeleton className="h-32 w-full rounded-[12px]" />
+          <Skeleton className="h-32 w-full rounded-[12px]" />
+          <Skeleton className="h-32 w-full rounded-[12px]" />
+          <Skeleton className="h-32 w-full rounded-[12px]" />
         </div>
       </div>
     );
@@ -198,7 +202,7 @@ export default function RetroSurveyPage() {
               : 'bg-[#E5E5E5] text-[#9FA4A8]'
           }`}
         >
-          {isPending ? '저장 중...' : '결과보기'}
+          결과보기
         </button>
       </div>
     </div>

--- a/src/shared/ui/Skeleton.tsx
+++ b/src/shared/ui/Skeleton.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@/shared/lib/utils';
+
+interface SkeletonProps {
+  className?: string;
+}
+
+export default function Skeleton({ className }: SkeletonProps) {
+  return (
+    <div
+      className={cn('animate-pulse rounded bg-[#E5E5E5]', className)}
+      aria-hidden
+    />
+  );
+}

--- a/src/widgets/calendar/CalendarContent.tsx
+++ b/src/widgets/calendar/CalendarContent.tsx
@@ -9,6 +9,7 @@ import { incomeQueries } from '@/entities/income';
 import { masterDataQueries, type MasterData } from '@/entities/master-data';
 import CalendarHeader from '@/widgets/calendar/CalendarHeader';
 import CalendarGrid from '@/widgets/calendar/CalendarGrid';
+import CalendarSkeleton from '@/widgets/calendar/CalendarSkeleton';
 import DateBottomSheet from '@/widgets/calendar/DateBottomSheet';
 import PageHeader from '@/shared/ui/PageHeader';
 
@@ -53,20 +54,23 @@ export default function CalendarContent() {
   const { getAccessToken } = useToken();
   const token = getAccessToken();
 
-  const { data: expenses } = useQuery({
+  const { data: expenses, isLoading: isExpensesLoading } = useQuery({
     ...expenseQueries.monthly(token || '', year, month + 1),
     enabled: !!token,
   });
 
-  const { data: incomes } = useQuery({
+  const { data: incomes, isLoading: isIncomesLoading } = useQuery({
     ...incomeQueries.monthly(token || '', year, month + 1),
     enabled: !!token,
   });
 
-  const { data: masterData } = useQuery({
+  const { data: masterData, isLoading: isMasterDataLoading } = useQuery({
     ...masterDataQueries.data(token || ''),
     enabled: !!token,
   });
+
+  const isLoading =
+    !!token && (isExpensesLoading || isIncomesLoading || isMasterDataLoading);
 
   const { categoryMap, emotionMap, situationMap, paymentMethodMap } = useMemo(
     () => buildLookups(masterData),
@@ -152,6 +156,8 @@ export default function CalendarContent() {
       setMonth(month + 1);
     }
   };
+
+  if (isLoading) return <CalendarSkeleton />;
 
   return (
     <div className="flex flex-1 flex-col">

--- a/src/widgets/calendar/CalendarSkeleton.tsx
+++ b/src/widgets/calendar/CalendarSkeleton.tsx
@@ -1,0 +1,16 @@
+import Skeleton from '@/shared/ui/Skeleton';
+import PageHeader from '@/shared/ui/PageHeader';
+
+export default function CalendarSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col">
+      <PageHeader title="캘린더" backHref="/" />
+      <div className="px-4 pt-5">
+        <Skeleton className="h-24 w-full rounded-[12px]" />
+      </div>
+      <div className="flex flex-1 flex-col px-4 pt-3 pb-6">
+        <Skeleton className="w-full flex-1 rounded-[12px]" />
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/report/CategoryDetailContent.tsx
+++ b/src/widgets/report/CategoryDetailContent.tsx
@@ -7,6 +7,7 @@ import { useToken } from '@/shared/store';
 import { reportQueries, type CategoryExpense } from '@/entities/report';
 import { getCategoryEmoji } from '@/shared/constants/categoryEmojiMap';
 import PageHeader from '@/shared/ui/PageHeader';
+import Skeleton from '@/shared/ui/Skeleton';
 import SortButton, { type SortType } from '@/shared/ui/SortButton';
 
 interface CategoryDetailContentProps {
@@ -137,6 +138,20 @@ export default function CategoryDetailContent({ categoryId }: CategoryDetailCont
   const categoryName = data?.category.categoryName ?? '';
   const totalAmount = data?.totalAmount ?? 0;
 
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 flex-col bg-white">
+        <PageHeader title="카테고리별 지출 항목" />
+        <div className="px-4 pt-3 pb-5">
+          <Skeleton className="h-16 w-60 rounded-[8px]" />
+        </div>
+        <div className="flex flex-1 flex-col px-4 pt-3 pb-6">
+          <Skeleton className="w-full flex-1 rounded-[12px]" />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-1 flex-col bg-white">
       <PageHeader title="카테고리별 지출 항목" />
@@ -163,11 +178,7 @@ export default function CategoryDetailContent({ categoryId }: CategoryDetailCont
         <SortButton sortType={sortType} onSortChange={setSortType} />
       </div>
 
-      {isLoading ? (
-        <div className="flex flex-1 items-center justify-center py-20">
-          <p className="text-[14px] text-[#9FA4A8]">불러오는 중...</p>
-        </div>
-      ) : sortedItems.length === 0 ? (
+      {sortedItems.length === 0 ? (
         <div className="flex flex-1 flex-col items-center justify-center py-20">
           <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#474C52]">
             아직 등록된 지출이 없어요

--- a/src/widgets/report/EmotionDetailContent.tsx
+++ b/src/widgets/report/EmotionDetailContent.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useToken } from '@/shared/store';
 import { reportQueries, type CategoryExpense } from '@/entities/report';
 import PageHeader from '@/shared/ui/PageHeader';
+import Skeleton from '@/shared/ui/Skeleton';
 import SortButton, { type SortType } from '@/shared/ui/SortButton';
 import EmotionIcon from '@/shared/ui/EmotionIcon';
 
@@ -142,6 +143,20 @@ export default function EmotionDetailContent({ emotionId }: EmotionDetailContent
   const emotionName = data?.emotion.emotionName ?? '';
   const totalAmount = data?.totalAmount ?? 0;
 
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 flex-col bg-white">
+        <PageHeader title="감정별 지출 항목" />
+        <div className="px-4 pt-3 pb-5">
+          <Skeleton className="h-16 w-60 rounded-[8px]" />
+        </div>
+        <div className="flex flex-1 flex-col px-4 pt-3 pb-6">
+          <Skeleton className="w-full flex-1 rounded-[12px]" />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-1 flex-col bg-white">
       <PageHeader title="감정별 지출 항목" />
@@ -164,11 +179,7 @@ export default function EmotionDetailContent({ emotionId }: EmotionDetailContent
         <SortButton sortType={sortType} onSortChange={setSortType} />
       </div>
 
-      {isLoading ? (
-        <div className="flex flex-1 items-center justify-center py-20">
-          <p className="text-[14px] text-[#9FA4A8]">불러오는 중...</p>
-        </div>
-      ) : sortedItems.length === 0 ? (
+      {sortedItems.length === 0 ? (
         <div className="flex flex-1 flex-col items-center justify-center py-20">
           <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#474C52]">
             아직 등록된 지출이 없어요

--- a/src/widgets/report/MonthlyExpenseContent.tsx
+++ b/src/widgets/report/MonthlyExpenseContent.tsx
@@ -9,6 +9,7 @@ import {
   type MonthlyExpenseItem,
 } from '@/entities/report';
 import PageHeader from '@/shared/ui/PageHeader';
+import Skeleton from '@/shared/ui/Skeleton';
 import SortButton, { type SortType } from '@/shared/ui/SortButton';
 import EmotionIcon from '@/shared/ui/EmotionIcon';
 
@@ -153,6 +154,20 @@ export default function MonthlyExpenseContent() {
   const isDateSort = sortType === 'latest' || sortType === 'oldest';
   const totalAmount = data?.totalAmount ?? 0;
 
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 flex-col bg-white">
+        <PageHeader title="이번 달 지출" />
+        <div className="px-4 pt-3 pb-5">
+          <Skeleton className="h-9 w-40 rounded-[8px]" />
+        </div>
+        <div className="flex flex-1 flex-col px-4 pt-3 pb-6">
+          <Skeleton className="w-full flex-1 rounded-[12px]" />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-1 flex-col bg-white">
       <PageHeader title="이번 달 지출" />
@@ -167,11 +182,7 @@ export default function MonthlyExpenseContent() {
         <SortButton sortType={sortType} onSortChange={setSortType} />
       </div>
 
-      {isLoading ? (
-        <div className="flex flex-1 items-center justify-center py-20">
-          <p className="text-[14px] text-[#9FA4A8]">불러오는 중...</p>
-        </div>
-      ) : sortedItems.length === 0 ? (
+      {sortedItems.length === 0 ? (
         <div className="flex flex-1 flex-col items-center justify-center py-20">
           <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#474C52]">
             아직 등록된 지출이 없어요

--- a/src/widgets/report/ReportContent.tsx
+++ b/src/widgets/report/ReportContent.tsx
@@ -15,7 +15,7 @@ import EmotionList from '@/widgets/report/EmotionList';
 import SituationTags from '@/widgets/report/SituationTags';
 import Footer from '@/shared/ui/Footer';
 import PageHeader from '@/shared/ui/PageHeader';
-import FullScreenLoader from '@/shared/ui/FullScreenLoader';
+import ReportSkeleton from '@/widgets/report/ReportSkeleton';
 import { AuthGuard } from '@/shared/ui/guard/AuthGuard';
 
 const CATEGORY_COLORS = ['#13278A', '#1BC590', '#FFDB72', '#E5E5E5', '#FFFFFF'];
@@ -122,12 +122,17 @@ export default function ReportContent() {
 
   const isLoadingData = !isMounted || !isLoaded || isLoading;
 
+  if (isLoadingData) {
+    return (
+      <AuthGuard>
+        <ReportSkeleton />
+      </AuthGuard>
+    );
+  }
+
   return (
     <AuthGuard>
-      <FullScreenLoader isLoading={isLoadingData} />
-      <div
-        className={`flex flex-1 flex-col bg-white ${isLoadingData ? 'pointer-events-none' : ''}`}
-      >
+      <div className="flex flex-1 flex-col bg-white">
         <PageHeader title="리포트" showBack={false} />
 
         <div className="flex flex-col gap-6.25 px-4 pt-5 pb-30">

--- a/src/widgets/report/ReportSkeleton.tsx
+++ b/src/widgets/report/ReportSkeleton.tsx
@@ -1,0 +1,17 @@
+import Skeleton from '@/shared/ui/Skeleton';
+import PageHeader from '@/shared/ui/PageHeader';
+
+export default function ReportSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col bg-white">
+      <PageHeader title="리포트" showBack={false} />
+      <div className="flex flex-col gap-6.25 px-4 pt-5 pb-30">
+        <Skeleton className="h-32 w-full rounded-[12px]" />
+        <Skeleton className="h-40 w-full rounded-[12px]" />
+        <Skeleton className="h-90 w-full rounded-[12px]" />
+        <Skeleton className="h-60 w-full rounded-[12px]" />
+        <Skeleton className="h-80 w-full rounded-[12px]" />
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/retro/RetroContent.tsx
+++ b/src/widgets/retro/RetroContent.tsx
@@ -7,7 +7,9 @@ import { useToken } from '@/shared/store';
 import { reportQueries } from '@/entities/report';
 import RetroEmpty from '@/widgets/retro/RetroEmpty';
 import RetroMain from '@/widgets/retro/RetroMain';
+import RetroSkeleton from '@/widgets/retro/RetroSkeleton';
 import PageHeader from '@/shared/ui/PageHeader';
+import Skeleton from '@/shared/ui/Skeleton';
 
 export default function RetroContent() {
   const router = useRouter();
@@ -35,17 +37,23 @@ export default function RetroContent() {
       <PageHeader title="회고하기" backHref="/" />
 
       <div className="px-4 pt-5">
-        <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#73787E]">
-          {mounted ? `${month}월 ${day}일 지출` : ''}
-        </p>
-        <p className="text-[28px] font-semibold leading-normal tracking-[-0.7px] text-[#030303]">
-          {totalExpense.toLocaleString()}원
-        </p>
+        {!mounted || isLoading ? (
+          <Skeleton className="h-16 w-full rounded-[8px]" />
+        ) : (
+          <>
+            <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#73787E]">
+              {`${month}월 ${day}일 지출`}
+            </p>
+            <p className="text-[28px] font-semibold leading-normal tracking-[-0.7px] text-[#030303]">
+              {totalExpense.toLocaleString()}원
+            </p>
+          </>
+        )}
       </div>
 
       <div className="flex flex-1 items-start justify-center px-4 pt-5 pb-6">
         {!mounted || isLoading ? (
-          <p className="py-10 text-[14px] text-[#9FA4A8]">불러오는 중...</p>
+          <RetroSkeleton />
         ) : hasData && data ? (
           <RetroMain
             expenseGraph={data.expenseGraph}

--- a/src/widgets/retro/RetroResultContent.tsx
+++ b/src/widgets/retro/RetroResultContent.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useToken } from '@/shared/store';
 import { reviewQueries } from '@/entities/review';
 import PageHeader from '@/shared/ui/PageHeader';
+import Skeleton from '@/shared/ui/Skeleton';
 
 function todayDateString(): string {
   const d = new Date();
@@ -33,8 +34,10 @@ export default function RetroResultContent() {
       />
 
       {isLoading || !data ? (
-        <div className="flex flex-1 items-center justify-center py-20">
-          <p className="text-[14px] text-[#9FA4A8]">불러오는 중...</p>
+        <div className="flex flex-col gap-6 px-4 pt-5 pb-25">
+          <Skeleton className="h-30 w-full rounded-xl" />
+          <Skeleton className="h-32 w-full rounded-xl" />
+          <Skeleton className="h-40 w-full rounded-xl" />
         </div>
       ) : (
         <div className="flex flex-col gap-10 px-4 pt-5 pb-25">

--- a/src/widgets/retro/RetroSkeleton.tsx
+++ b/src/widgets/retro/RetroSkeleton.tsx
@@ -1,0 +1,10 @@
+import Skeleton from '@/shared/ui/Skeleton';
+
+export default function RetroSkeleton() {
+  return (
+    <div className="flex w-full flex-col gap-5">
+      <Skeleton className="h-90 w-full rounded-[12px]" />
+      <Skeleton className="h-21.25 w-full rounded-[12px]" />
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 내용                                                                  
                                                                                                                                             
  기존에 일관성 없이 흩어져있던 로딩 처리(`불러오는 중...` 텍스트, `FullScreenLoader`, 무처리 등)를 페이지별 스켈레톤 패턴으로 통일.
                                                                                                                                             
  ### 공통                                                                      
  - `shared/ui/Skeleton.tsx` 신설 — `animate-pulse` + `bg-[#E5E5E5]` 기반 placeholder                                                        
                                                                                     
  ### 메인 페이지                                                                                                                            
  - 캘린더 — `CalendarSkeleton` 신설, `isLoading` 분기 추가
  - 회고 — `RetroSkeleton` 신설, `불러오는 중...` 텍스트 제거                                                                                
  - 리포트 — `ReportSkeleton` 신설, `FullScreenLoader` 제거                    
                                                                                                                                             
  ### 리포트 디테일 (이번 달 지출 / 카테고리별 / 감정별)                        
  - 페이지 전체 로딩 시 본문 영역을 큰 박스 스켈레톤으로 통째 교체                                                                           
  - 기존 `불러오는 중...` 텍스트 제거                                                                                                        
                                                                                                                                             
  ### 회고 흐름                                                                                                                              
  - 문항 페이지(`/retro/survey`) — 4개 질문 영역을 큰 박스 4개로                                                                             
  - 결과 페이지(`/retro/result`) — 결과 카드 3개를 큰 박스 3개로                                                                             
  - 결과보기 버튼의 `저장 중...` 텍스트 제거 (disabled는 유지)                                                                               
                                                                                                                                             
  ### 패턴                                                                                                                                   
  - `useQuery`의 `isLoading`으로 분기 → 로딩 중 페이지 전체 스켈레톤 반환                                                                    
  - 큰 박스 placeholder 위주 (세부 line skeleton 지양)                                                                                       
  - `flex-1`로 viewport 끝까지 채워 layout shift 방지