### PR TITLE
[FIX] QA 수정

### DIFF
--- a/src/app/BackgroundProvider.tsx
+++ b/src/app/BackgroundProvider.tsx
@@ -28,7 +28,7 @@ export default function BackgroundProvider({ children }: { children: React.React
   }, [pathname]);
 
   return (
-    <div className="min-h-dvh w-full bg-gray-100">
+    <div className="min-h-screen w-full bg-gray-100">
       <div
         className={cn(
           'mx-auto flex min-h-dvh w-full max-w-md flex-col',

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -7,6 +7,7 @@ import CommonFeature from '@/shared/ui/my-page/CommonFeature';
 import { useUser } from '@/shared/store';
 import { AuthGuard } from '@/shared/ui/guard/AuthGuard';
 import { LogoutModal } from '@/features/logout/ui/LogoutModal';
+import Footer from '@/shared/ui/Footer';
 
 
 export default function MyPage() {
@@ -18,13 +19,14 @@ export default function MyPage() {
     <AuthGuard>
       <PageHeader title={'마이페이지'} />
       <UserBox />
-      <CommonFeature title={'알림'} secondary={'푸시 알림'} />
+      <CommonFeature title={'푸시 알림'} secondary={'푸시 알림'} />
       <CommonFeature
-        title={'계정 관리'}
+        title={'로그아웃'}
         secondary={user?.nickname.startsWith('guest') ? '로그인하기' : '로그아웃'}
         changeLogoutModal={(bool: boolean) =>  setIsLogoutModalOpen(bool)}
       />
       <LogoutModal isOpen={isLogoutModalOpen} onClose={setIsLogoutModalOpen} />
+      <Footer />
     </AuthGuard>
   );
 }

--- a/src/entities/user/ui/UserBox.tsx
+++ b/src/entities/user/ui/UserBox.tsx
@@ -11,21 +11,33 @@ export function UserBox() {
   const query = useUserGetter(accessToken);
 
   return (
-    <div className={"user-box-wrapper px-5"}>
-      <div className={"user-box mt-5 mb-6.25 bg-gray-200 p-4 rounded-[12px] flex gap-3"}>
-        <div className={"profile w-15 h-15 rounded-full relative"}>
-          <Image src={"/svg/free_log_chc.png"} alt={"profile"} fill />
+    <div className={'user-box-wrapper px-5'}>
+      <div
+        className={
+          'user-box bg-gray-1푸시 알림 토글 버튼색과 크기 맞추기00 mt-5 mb-6.25 flex gap-3 rounded-[12px] p-4'
+        }
+      >
+        <div className={'profile relative h-15 w-15 rounded-full'}>
+          <Image src={'/svg/free_log_chc.png'} alt={'profile'} fill />
         </div>
-        <div className={"info p-1.25 flex flex-col justify-center"}>
-          {(query.isLoading || !user ) && <div className={"text-[14px]"}>정보를 불러오고 있습니다.</div>}
-          {!query.isLoading && user &&
+        <div className={'info flex flex-col justify-center p-1.25'}>
+          {(query.isLoading || !user) && (
+            <div className={'text-[14px]'}>정보를 불러오고 있습니다.</div>
+          )}
+          {!query.isLoading && user && (
             <>
-              <span className={"font-bold"}>{user ? user.nickname : "손님"}</span>
-              <span className={"text-[14px]"}>{user?.provider === 'GOOGLE' ? '구글로 로그인되었습니다.' : user?.provider === 'KAKAO' ? '카카오로 로그인되었습니다.' : '로그인하세요'}</span>
+              <span className={'font-bold'}>{user ? user.nickname : '손님'}</span>
+              <span className={'text-[14px]'}>
+                {user?.provider === 'GOOGLE'
+                  ? '구글로 로그인되었습니다.'
+                  : user?.provider === 'KAKAO'
+                    ? '카카오로 로그인되었습니다.'
+                    : '로그인하세요'}
+              </span>
             </>
-          }
+          )}
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/features/post-asset/api/post-asset-api.ts
+++ b/src/features/post-asset/api/post-asset-api.ts
@@ -13,3 +13,16 @@ export function postAssetApi(req: AssetRequestBody) {
     body: JSON.stringify(req)
   });
 }
+
+export function patchAssetApi(assetId: number, req: AssetRequestBody) {
+  return apiClient(`/api/v1/assets/${assetId}`, {
+    method: "PATCH",
+    body: JSON.stringify(req)
+  });
+}
+
+export function deleteAssetApi(assetId: number) {
+  return apiClient(`/api/v1/assets/${assetId}`, {
+    method: "DELETE"
+  });
+}

--- a/src/shared/constants/greetingMessages.ts
+++ b/src/shared/constants/greetingMessages.ts
@@ -7,7 +7,7 @@ export interface GreetingMessage {
 export const greetingMessages: GreetingMessage[] = [
   {
     title: '사고 싶은 건 한번 더 생각!',
-    secondary: '작은 절약이 큰 변화를 만들어요.',
+    secondary: '작은 절약이 큰 변화를 만들어요',
     image: '/svg/gm/pig.svg'
   },
   {

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -17,15 +17,15 @@ export default function Button({
   disabled,
   ...props
 }: ButtonProps) {
-  const baseStyles = 'font-medium transition-colors rounded-[10px]';
+  const baseStyles = 'font-medium transition-colors rounded-[10px] cursor-pointer';
 
   const variantStyles = {
     primary: disabled
       ? 'bg-[#E5E5E5] text-[#9FA4A8] cursor-not-allowed'
-      : 'bg-[#13278a] text-white hover:bg-gray-800 cursor-pointer',
+      : 'bg-[#13278a] text-white cursor-pointer',
     secondary: isActive
       ? 'border border-black text-black'
-      : 'border border-gray-300 text-gray-700 hover:border-gray-400 opacity-45',
+      : 'border border-gray-300 text-gray-700 opacity-45',
     outline: 'border border-gray-200 text-gray-900 hover:border-gray-300',
   };
 

--- a/src/shared/ui/Footer.tsx
+++ b/src/shared/ui/Footer.tsx
@@ -12,7 +12,7 @@ const navItems = [
 ];
 
 
-function FooterIcon({ icon }: { icon: string }) {
+function FooterIcon({ icon, color }: { icon: string; color: string }) {
   switch (icon) {
     case 'household':
       return (
@@ -23,31 +23,31 @@ function FooterIcon({ icon }: { icon: string }) {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <rect x="7" y="13" width="16" height="12" fill="#1C1D1F" />
+          <rect x="7" y="13" width="16" height="12" fill={color} />
           <path
             d="M22 7H8C6.89543 7 6 7.89543 6 9V23C6 24.1046 6.89543 25 8 25H22C23.1046 25 24 24.1046 24 23V9C24 7.89543 23.1046 7 22 7Z"
-            stroke="#1C1D1F"
+            stroke={color}
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
           />
           <path
             d="M19 5V9.00001"
-            stroke="#1C1D1F"
+            stroke={color}
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
           />
           <path
             d="M11 5V9.00001"
-            stroke="#1C1D1F"
+            stroke={color}
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
           />
           <path
             d="M6 13H24"
-            stroke="#1C1D1F"
+            stroke={color}
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -79,14 +79,14 @@ function FooterIcon({ icon }: { icon: string }) {
         >
           <path
             d="M5 6L5 24H25"
-            stroke="black"
+            stroke={color}
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
           />
           <path
             d="M9.73193 17.6201L14.5401 12.4646L17.8105 15.7154L23.7319 9.62012"
-            stroke="black"
+            stroke={color}
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -102,7 +102,7 @@ function FooterIcon({ icon }: { icon: string }) {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <circle cx="15" cy="14.8691" r="10" fill="black" stroke="black" strokeWidth="2" />
+          <circle cx="15" cy="14.8691" r="10" fill={color} stroke={color} strokeWidth="2" />
           <path
             d="M10.2002 12L12.1472 18.26C12.1771 18.3563 12.2398 18.4412 12.3261 18.5024C12.4123 18.5636 12.5177 18.5977 12.6266 18.5999C12.7356 18.602 12.8425 18.5721 12.9315 18.5144C13.0206 18.4567 13.0872 18.3743 13.1216 18.2793L15.0002 13.1023L16.8788 18.2793C16.9132 18.3743 16.9798 18.4567 17.0689 18.5144C17.1579 18.5721 17.2648 18.602 17.3737 18.5999C17.4827 18.5977 17.5881 18.5636 17.6743 18.5024C17.7606 18.4412 17.8233 18.3563 17.8532 18.26L19.8002 12"
             stroke="white"
@@ -130,19 +130,19 @@ function FooterIcon({ icon }: { icon: string }) {
         >
           <path
             d="M14.5003 13.2964C16.7913 13.2964 18.6485 11.4392 18.6485 9.14821C18.6485 6.85722 16.7913 5 14.5003 5C12.2093 5 10.3521 6.85722 10.3521 9.14821C10.3521 11.4392 12.2093 13.2964 14.5003 13.2964Z"
-            fill="#000"
-            stroke="#000"
+            fill={color}
+            stroke={color}
             strokeWidth="1.9"
             strokeLinecap="round"
             strokeLinejoin="round"
           />
           <path
             d="M24 24.0004V21.708C24 20.492 23.4996 19.3258 22.6088 18.4659C21.718 17.6061 20.5098 17.123 19.25 17.123H9.75C8.49022 17.123 7.28204 17.6061 6.39124 18.4659C5.50044 19.3258 5 20.492 5 21.708V24.0004"
-            fill="#000"
+            fill={color}
           />
           <path
             d="M24 24.0004V21.708C24 20.492 23.4996 19.3258 22.6088 18.4659C21.718 17.6061 20.5098 17.123 19.25 17.123H9.75C8.49022 17.123 7.28204 17.6061 6.39124 18.4659C5.50044 19.3258 5 20.492 5 21.708V24.0004H24Z"
-            stroke="#000"
+            stroke={color}
             strokeWidth="1.9"
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -193,7 +193,7 @@ export default function Footer() {
                 isActive ? 'text-[#1c1d1f] opacity-100' : 'text-[#9fa4a8] opacity-50'
               }`}
             >
-              <FooterIcon icon={item.icon} />
+              <FooterIcon icon={item.icon} color={isActive ? '#1c1d1f' : '#9fa4a8' } />
               <span className="text-[14px] font-medium tracking-[-0.025em] whitespace-nowrap">{item.label}</span>
             </button>
             );
@@ -212,7 +212,7 @@ export default function Footer() {
                 isActive ? 'text-[#1c1d1f] opacity-100' : 'text-[#9fa4a8] opacity-50'
               }`}
             >
-              <FooterIcon icon={item.icon} />
+              <FooterIcon icon={item.icon} color={isActive ? '#1c1d1f' : '#9fa4a8' } />
               <span className="text-[14px] font-medium tracking-[-0.025em] whitespace-nowrap">{item.label}</span>
             </button>
             );

--- a/src/shared/ui/SelectField.tsx
+++ b/src/shared/ui/SelectField.tsx
@@ -28,7 +28,7 @@ export default function SelectField({
       >
         {hasValue ? (
           typeof value === 'string' ? (
-            <span className={`text-[17px] font-semibold tracking-[-0.025em] transition-colors ${
+            <span className={`text-[16px] font-medium tracking-[-0.025em] transition-colors ${
               isDefault ? 'text-[#9fa4a8]' : 'text-[#13278a]'
             }`}>
               {value}

--- a/src/shared/ui/house-hold/TodayExpenseBox.tsx
+++ b/src/shared/ui/house-hold/TodayExpenseBox.tsx
@@ -67,9 +67,9 @@ export default function TodayExpenseBox({ emotions, expenseCategories }: TodayEx
 
     dailyExpenseList.forEach((expense) => {
       if (!categoryMap.has(expense.categoryId)) {
-        const categoryLabel = expenseCategories
-          .flatMap((g) => g.items)
-          .find((item) => item.id === expense.categoryId)?.label || '기타';
+        const categoryLabel = expenseCategories && Array.isArray(expenseCategories)
+          ? expenseCategories.flatMap((g) => g.items).find((item) => item.id === expense.categoryId)?.label || '기타'
+          : '기타';
 
         categoryMap.set(expense.categoryId, {
           name: categoryLabel,
@@ -83,7 +83,9 @@ export default function TodayExpenseBox({ emotions, expenseCategories }: TodayEx
       // emotionIds를 사용해서 emotion 정보 추가
       if (expense.emotionIds && expense.emotionIds.length > 0) {
         expense.emotionIds.forEach((emotionId) => {
-          const emotion = emotions.flatMap((g) => g.items).find((item) => item.id === emotionId);
+          const emotion = emotions && Array.isArray(emotions)
+            ? emotions.flatMap((g) => g.items).find((item) => item.id === emotionId)
+            : undefined;
           if (emotion && !category.emotions.find((e) => e.id === emotion.id)) {
             category.emotions.push(emotion);
           }
@@ -132,7 +134,7 @@ export default function TodayExpenseBox({ emotions, expenseCategories }: TodayEx
         </button>
       </div>
 
-      <div className={cn('flex items-center gap-0.75', totalAmount === 0 ? 'mb-2' : 'mb-6')}>
+      <div className={cn('flex items-center gap-0.75', totalAmount === 0 ? 'mb-2' : 'mb-3')}>
         <button
           onClick={handlePrevDay}
           disabled={!canGoPrev}
@@ -170,7 +172,7 @@ export default function TodayExpenseBox({ emotions, expenseCategories }: TodayEx
 
       {totalAmount === 0 ? (
         <div className="flex flex-col items-center justify-center">
-          <p className="mb-4 self-start text-[14px] font-medium text-gray-500">
+          <p className="mb-4 self-start text-[16px] font-medium text-gray-500">
             아직 지출이 없어요
           </p>
           <button

--- a/src/shared/ui/my-page/CommonFeature.tsx
+++ b/src/shared/ui/my-page/CommonFeature.tsx
@@ -60,13 +60,15 @@ export default function CommonFeature({ title, secondary, changeLogoutModal }: {
 
   return (
     <div className={'common__menu px-5 mb-4'}>
-      <h2 className={'mb-2 text-[14px] font-bold text-gray-500'}>{title}</h2>
+      <h2 className={'mb-2 text-[14px] font-medium text-gray-500'}>{title}</h2>
       {secondary === '푸시 알림' && (
         <div className={'flex justify-between items-center w-full'}>
           <span className={'text-[14px] font-bold'}>{secondary}</span>
           <button
-            className={`h-8 w-14.5 rounded-full relative bg-[#13278a] after:absolute after:top-0 after:bottom-0 after:my-auto after:h-5 after:w-5 after:rounded-full after:bg-white after:content-[''] transition-all ${
-              isPushedNotification ? 'after:right-1.5' : 'after:left-1.5 opacity-45'
+            className={`h-6 w-11 rounded-full relative transition-all ${
+              isPushedNotification ? 'bg-[#13278a]' : 'bg-[#E5E5E5]'
+            } after:absolute after:top-1/2 after:-translate-y-1/2 after:h-4 after:w-4 after:rounded-full after:bg-white after:content-[''] ${
+              isPushedNotification ? 'after:right-1' : 'after:left-1'
             } ${isLoading ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
             onClick={switchNotification}
             disabled={isLoading}

--- a/src/widgets/asset/AssetContent.tsx
+++ b/src/widgets/asset/AssetContent.tsx
@@ -88,7 +88,7 @@ export default function AssetContent() {
             아직 등록된 자산이 없어요
           </p>
           <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#9FA4A8]">
-            자산을 등록하고 한눈에 관리해보세요.
+            자산을 등록하고 한눈에 관리해보세요
           </p>
         </div>
       ) : (

--- a/src/widgets/asset/AssetDetailContent.tsx
+++ b/src/widgets/asset/AssetDetailContent.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
+import { useRouter } from 'next/navigation';
 import PageHeader from '@/shared/ui/PageHeader';
 import Footer from '@/shared/ui/Footer';
 import SortButton, { SortType } from '@/shared/ui/SortButton';
+import ConfirmModal from '@/shared/ui/ConfirmModal';
 import { ASSET_CATEGORIES } from '@/shared/constants/assetData';
 import { useGetAssets } from '@/entities/get-assets/useGetAssets';
+import { deleteAssetApi } from '@/features/post-asset/api/post-asset-api';
+import { Trash2 } from 'lucide-react';
 
 interface AssetDetailContentProps {
   categoryId: string;
@@ -36,9 +40,14 @@ function formatRecordDate(date: string): string {
 }
 
 export default function AssetDetailContent({ categoryId }: AssetDetailContentProps) {
+  const router = useRouter();
   const category = ASSET_CATEGORIES.find(cat => cat.id === categoryId);
   const apiCategoryId = CATEGORY_ID_MAP[categoryId];
   const [sortType, setSortType] = useState<SortType>('latest');
+  const [swipedId, setSwipedId] = useState<number | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const touchStartX = useRef(0);
 
   const { data: assetsData, isLoading } = useGetAssets({
     categoryId: apiCategoryId,
@@ -46,6 +55,44 @@ export default function AssetDetailContent({ categoryId }: AssetDetailContentPro
     page: 0,
     size: 100,
   });
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    touchStartX.current = e.clientX;
+  };
+
+  const handlePointerUp = (e: React.PointerEvent, assetId: number) => {
+    const touchEndX = e.clientX;
+    const diff = touchStartX.current - touchEndX;
+
+    if (diff > 30) {
+      setSwipedId(assetId);
+      e.preventDefault();
+    } else if (diff < -30) {
+      setSwipedId(null);
+    }
+  };
+
+  const handleAssetClick = (e: React.MouseEvent, assetId: number) => {
+    const diff = Math.abs(touchStartX.current - e.clientX);
+    if (diff < 30) {
+      router.push(`/record?assetId=${assetId}&type=asset`);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (deleteTargetId === null) return;
+
+    setIsDeleting(true);
+    try {
+      await deleteAssetApi(deleteTargetId);
+      setDeleteTargetId(null);
+      setSwipedId(null);
+      // 목록 새로고침을 위해 쿼리 재실행 (useGetAssets가 자동으로 처리)
+    } catch (error) {
+      alert('삭제 중 오류가 발생했습니다.');
+      setIsDeleting(false);
+    }
+  };
 
   if (!category) {
     return (
@@ -116,25 +163,62 @@ export default function AssetDetailContent({ categoryId }: AssetDetailContentPro
         ) : (
           <div className="flex flex-col gap-5 mt-4">
             {records.map((record, idx) => (
-              <div key={idx} className="flex flex-col gap-0.75">
-                <div className="flex items-center justify-between">
-                  <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#474C52]">
-                    {formatRecordDate(record.assetDate)}
-                  </p>
-                  <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
-                    {record.amount.toLocaleString()}원
-                  </p>
+              <div
+                key={idx}
+                className="relative overflow-hidden rounded-lg"
+                onPointerDown={handlePointerDown}
+                onPointerUp={(e) => handlePointerUp(e, record.assetId)}
+                style={{ touchAction: 'pan-y' }}
+              >
+                {/* 삭제 버튼 배경 */}
+                <div className="absolute inset-y-0 right-0 z-0 flex items-center justify-end pr-4">
+                  <button
+                    onClick={() => setDeleteTargetId(record.assetId)}
+                    className="bg-[#eb1c1c] text-white w-10 h-10 flex justify-center items-center rounded-full"
+                    aria-label="삭제"
+                  >
+                    <Trash2 size={24} />
+                  </button>
                 </div>
-                {record.memo && (
-                  <p className="text-right text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#9FA4A8]">
-                    {record.memo}
-                  </p>
-                )}
+
+                {/* 컨텐츠 */}
+                <button
+                  className={`relative z-10 w-full text-left bg-white transition-transform duration-300 cursor-pointer flex flex-col gap-0.75 pb-3.75 ${
+                    swipedId === record.assetId ? 'translate-x-[-80px]' : ''
+                  }`}
+                  onClick={(e) => handleAssetClick(e, record.assetId)}
+                >
+                  <div className="flex items-center justify-between">
+                    <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#474C52]">
+                      {formatRecordDate(record.assetDate)}
+                    </p>
+                    <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
+                      {record.amount.toLocaleString()}원
+                    </p>
+                  </div>
+                  {record.memo && (
+                    <p className="text-right text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#9FA4A8]">
+                      {record.memo}
+                    </p>
+                  )}
+                </button>
               </div>
             ))}
           </div>
         )}
       </div>
+
+      {/* 삭제 확인 모달 */}
+      <ConfirmModal
+        isOpen={deleteTargetId !== null}
+        title="자산을 삭제하시겠어요?"
+        message="이 작업은 되돌릴 수 없습니다."
+        confirmText="삭제"
+        cancelText="취소"
+        isDangerous={true}
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteTargetId(null)}
+      />
 
       <Footer />
     </div>

--- a/src/widgets/export/ExportContent.tsx
+++ b/src/widgets/export/ExportContent.tsx
@@ -230,38 +230,23 @@ export default function ExportContent() {
                         </p>
                       </div>
 
-                      {/* 태그 + 감정 + 결제수단 */}
-                      <div className="flex items-center justify-between gap-1.25">
-                        <div className="flex items-center gap-2">
+                      {/* 태그 + 메모 */}
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-1">
                           {expense.tag && expense.tag.length > 0 && (
-                            <div className="flex items-center gap-1.5">
-                              {expense.tag.map((tag, tagIdx) => (
-                                <span
-                                  key={tagIdx}
-                                  className="text-[16px] font-medium tracking-[-0.025em] text-[#13278a]"
-                                >
-                                  {tag}
-                                </span>
-                              ))}
-                            </div>
+                            <span className="text-[16px] font-medium tracking-[-0.025em] text-[#13278a]">
+                              {expense.tag.join(', ')}
+                            </span>
                           )}
-                          {expense.emotions.length > 0 && (
-                            <>
-                              <span className="h-3.5 w-px shrink-0 bg-[#e5e5e5]" />
-                              <div className="flex items-center gap-1.5">
-                                {expense.emotions.map((emotion) => (
-                                  emotion.emoji && (
-                                    <Image
-                                      key={emotion.label}
-                                      src={emotion.emoji}
-                                      alt={emotion.label}
-                                      width={20}
-                                      height={20}
-                                    />
-                                  )
-                                ))}
-                              </div>
-                            </>
+                          {expense.tag && expense.tag.length > 0 && expense.memo && (
+                            <span className="text-[16px] font-medium tracking-[-0.025em] text-[#9fa4a8]">
+                              |
+                            </span>
+                          )}
+                          {expense.memo && (
+                            <span className="text-[16px] font-medium tracking-[-0.025em] text-[#9fa4a8]">
+                              {expense.memo}
+                            </span>
                           )}
                         </div>
                         <span className="text-[16px] font-medium tracking-[-0.025em] text-[#9fa4a8]">
@@ -269,11 +254,28 @@ export default function ExportContent() {
                         </span>
                       </div>
 
-                      {/* 메모 */}
-                      {expense.memo && (
-                        <span className="text-[16px] font-medium tracking-[-0.025em] text-[#9fa4a8]">
-                          {expense.memo}
-                        </span>
+                      {/* 감정 */}
+                      {expense.emotions.length > 0 && (
+                        <div className="flex items-center gap-1.5">
+                          {expense.emotions.map((emotion, idx) => (
+                            <span key={idx} className="flex items-center gap-1">
+                              {emotion.emoji && (
+                                <Image
+                                  src={emotion.emoji}
+                                  alt={emotion.label}
+                                  width={18}
+                                  height={18}
+                                />
+                              )}
+                              <span className="text-[14px] font-medium tracking-[-0.025em] text-[#474c52]">
+                                {emotion.label}
+                              </span>
+                              {idx < expense.emotions.length - 1 && (
+                                <span className="text-[14px] text-[#9fa4a8]">,</span>
+                              )}
+                            </span>
+                          ))}
+                        </div>
                       )}
                     </div>
                   </div>

--- a/src/widgets/record/RecordContent.tsx
+++ b/src/widgets/record/RecordContent.tsx
@@ -15,6 +15,7 @@ import { useMasterData } from '@/entities/master-data';
 import { useHouseHoldPost } from '@/features/post-house-hold/model/useHouseHoldPost';
 import { useUpdateExpense } from '@/features/update-expense/model/useUpdateExpense';
 import { useDailyExpend } from '@/entities/daily-expend/model/useDailyExpend';
+import { useGetAssets } from '@/entities/get-assets/useGetAssets';
 import { usePostAsset } from '@/features/post-asset/model/usePostAsset';
 import { usePostIncome } from '@/features/post-income/model/usePostIncome';
 import { evaluate } from 'mathjs';
@@ -121,8 +122,10 @@ export default function RecordContent() {
   const selectedDate = searchParams?.get('date') || today;
   const typeParam = searchParams?.get('type');
   const expenseIdParam = searchParams?.get('expenseId');
+  const assetIdParam = searchParams?.get('assetId');
   const modeParam = searchParams?.get('mode');
   const isEditMode = modeParam === 'edit' && expenseIdParam;
+  const isAssetEditMode = typeParam === 'asset' && assetIdParam;
   const isAssetMode = typeParam === 'asset';
   const initialType: 'income' | 'expense' =
     typeParam === 'income' || isAssetMode ? 'income' : 'expense';
@@ -132,6 +135,13 @@ export default function RecordContent() {
   const expenseMonth = parseInt(selectedDate.split('-')[1]);
   const expenseDay = parseInt(selectedDate.split('-')[2]);
   const { data: dailyExpenseData = [] } = useDailyExpend(expenseYear, expenseMonth, expenseDay);
+
+  // 자산 edit 모드일 때 자산 데이터 로드
+  const { data: assetsData } = useGetAssets({
+    sort: 'LATEST',
+    page: 0,
+    size: 100,
+  });
 
   const [record, setRecord] = useState<RecordState>({
     amount: 0,
@@ -170,6 +180,30 @@ export default function RecordContent() {
       }
     }
   }, [isEditMode, expenseIdParam, dailyExpenseData]);
+
+  // 자산 edit 모드일 때 초기값 설정
+  useEffect(() => {
+    if (isAssetEditMode && assetIdParam && assetsData?.data) {
+      const asset = assetsData.data.find(
+        (a) => a.assetId === parseInt(assetIdParam)
+      );
+      if (asset) {
+        setRecord({
+          amount: asset.amount,
+          type: 'income',
+          date: asset.assetDate,
+          categoryId: asset.assetCategoryId,
+          paymentMethodId: null,
+          emotionIds: [],
+          situationTagIds: [],
+          memo: asset.memo,
+        });
+        setAmountInput(asset.amount.toString());
+        setSelectedCategoryId(asset.assetCategoryId);
+        setTempMemo(asset.memo);
+      }
+    }
+  }, [isAssetEditMode, assetIdParam, assetsData?.data]);
 
   const [isCategoryOpen, setIsCategoryOpen] = useState(false);
   const [isPaymentOpen, setIsPaymentOpen] = useState(false);
@@ -465,7 +499,7 @@ export default function RecordContent() {
 
   return (
     <div className="min-h-dvh bg-white" onClick={() => isAmountEditing && setIsAmountEditing(false)}>
-      <PageHeader title={isEditMode ? '지출 수정' : isAssetMode ? '자산 추가' : '가계부'} />
+      <PageHeader title={isEditMode ? '지출 수정' : isAssetEditMode ? '자산 수정' : isAssetMode ? '자산 추가' : '가계부'} />
 
       <div className="px-6 py-6 pb-40">
         {/* Amount Section */}
@@ -721,13 +755,13 @@ export default function RecordContent() {
         height={record.type === 'expense' ? 636 : 492}
       >
         {isAssetMode ? (
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-2.5">
             {ASSET_CATEGORIES.map((category) => (
               <button
                 key={category.id}
                 onClick={() => handleCategorySelect(category.id)}
                 className={cn(
-                  'flex h-9.5 w-26.25 cursor-pointer items-center justify-center rounded-full border text-[16px] font-medium tracking-[-0.025em] transition-colors',
+                  'flex h-8 px-4 cursor-pointer items-center justify-center rounded-full border text-[14px] font-medium tracking-[-0.025em] transition-colors',
                   selectedCategoryId === category.id
                     ? 'border-[#13278a] bg-[#ecf2fb] text-[#13278a]'
                     : 'border-[#e5e5e5] text-[#474c52]'
@@ -738,13 +772,13 @@ export default function RecordContent() {
             ))}
           </div>
         ) : record.type === 'income' ? (
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-2.5">
             {INCOME_CATEGORIES.map((category) => (
               <button
                 key={category.id}
                 onClick={() => handleCategorySelect(category.id)}
                 className={cn(
-                  'flex h-9.5 w-26.25 cursor-pointer items-center justify-center rounded-full border text-[16px] font-medium tracking-[-0.025em] transition-colors',
+                  'flex h-8 px-4 cursor-pointer items-center justify-center rounded-full border text-[14px] font-medium tracking-[-0.025em] transition-colors',
                   selectedCategoryId === category.id
                     ? 'border-[#13278a] bg-[#ecf2fb] text-[#13278a]'
                     : 'border-[#e5e5e5] text-[#474c52]'
@@ -759,13 +793,13 @@ export default function RecordContent() {
             {expenseCategories.map((group) => (
               <div key={group.group} className="flex flex-col gap-3">
                 <h3 className="text-[18px] font-semibold tracking-[-0.025em] text-[#27282c]">{group.group}</h3>
-                <div className="flex flex-wrap gap-2">
+                <div className="flex flex-wrap gap-2.5">
                   {group.items.map((item) => (
                     <button
                       key={item.id}
                       onClick={() => handleCategorySelect(item.id)}
                       className={cn(
-                        'flex h-9.5 w-26.25 cursor-pointer items-center justify-center gap-2 rounded-full border text-[16px] font-medium tracking-[-0.025em] transition-colors',
+                        'flex h-8 px-4 cursor-pointer items-center justify-center gap-1.5 rounded-full border text-[14px] font-medium tracking-[-0.025em] transition-colors',
                         selectedCategoryId === item.id
                           ? 'border-[#13278a] bg-[#ecf2fb] text-[#13278a]'
                           : 'border-[#e5e5e5] text-[#474c52]'
@@ -795,13 +829,13 @@ export default function RecordContent() {
           isSaveDisabled={selectedPaymentId === null}
           height={492}
         >
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-2.5">
             {PAYMENT_METHODS.map((method) => (
               <button
                 key={method.id}
                 onClick={() => setSelectedPaymentId(method.id)}
                 className={cn(
-                  'flex h-9.5 w-26.25 cursor-pointer items-center justify-center rounded-full border text-[16px] font-medium tracking-[-0.025em] transition-colors',
+                  'flex h-8 px-4 cursor-pointer items-center justify-center rounded-full border text-[14px] font-medium tracking-[-0.025em] transition-colors',
                   selectedPaymentId === method.id
                     ? 'border-[#13278a] bg-[#ecf2fb] text-[#13278a]'
                     : 'border-[#e5e5e5] text-[#474c52]'
@@ -832,19 +866,19 @@ export default function RecordContent() {
             {emotions.map((group) => (
               <div key={group.group} className="flex flex-col gap-3">
                 <h3 className="text-[18px] font-semibold tracking-[-0.025em] text-[#27282c]">{group.group}</h3>
-                <div className="flex flex-wrap gap-2">
+                <div className="flex flex-wrap gap-2.5">
                   {group.items.map((item) => (
                     <button
                       key={item.id}
                       onClick={() => handleEmotionToggle(item.id)}
                       className={cn(
-                        'flex h-9.5 w-26.25 cursor-pointer items-center justify-center gap-2 rounded-full border text-[16px] font-medium tracking-[-0.025em] transition-colors',
+                        'flex h-8 px-4 cursor-pointer items-center justify-center gap-1.5 rounded-full border text-[14px] font-medium tracking-[-0.025em] transition-colors',
                         selectedEmotions.includes(item.id)
                           ? 'border-[#13278a] bg-[#ecf2fb] text-[#13278a]'
                           : 'border-[#e5e5e5] text-[#27282c]'
                       )}
                     >
-                      {item.emoji && <Image src={item.emoji} alt={item.label} width={24} height={24} />}
+                      {item.emoji && <Image src={item.emoji} alt={item.label} width={18} height={18} />}
                       <span>{item.label}</span>
                     </button>
                   ))}
@@ -891,13 +925,13 @@ export default function RecordContent() {
             {/* 상황 태그 Section */}
             <div className="flex flex-col gap-3">
               <h3 className="text-[18px] font-semibold tracking-[-0.025em] text-[#27282c]">상황 태그</h3>
-              <div className="flex flex-wrap gap-x-2 gap-y-2.5">
+              <div className="flex flex-wrap gap-2.5">
                 {situationTags.map((tag) => (
                   <button
                     key={tag.id}
                     onClick={() => handleTagToggle(tag.id)}
                     className={cn(
-                      'flex h-9.5 w-26.25 cursor-pointer items-center justify-center rounded-full border text-[16px] font-medium tracking-[-0.025em] transition-colors',
+                      'flex h-8 px-4 cursor-pointer items-center justify-center rounded-full border text-[14px] font-medium tracking-[-0.025em] transition-colors',
                       tempTags.includes(tag.id)
                         ? 'border-[#13278a] bg-[#ecf2fb] text-[#13278a]'
                         : 'border-[#e5e5e5] text-[#27282c]'


### PR DESCRIPTION
바텀 시트 색깔 변경

하단 네비게이션 아이콘 색깔 더 회색으로 변경

홈 화면의 '아직 지출이 없어요' 텍스트 크기와 날짜 크기 같게 조정

그리팅 메시지에 마침표 빼기

자산 0원일 때 '자산을 등록하고 한눈에 관리해보세요' 마침표 삭제하기

마이페이지 로그인 회색 박스 색 연하게 바꾸기

푸시 알림 토글 버튼색과 크기 맞추기

알림 -> 푸시알림 / 계정관리 -> 로그아웃 => 텍스트 굵기, 크기 맞추기 (Medium)

지출 등록할 때 날짜 텍스트만 굵기가 두꺼움

지출 > 결제 수단, 카테고리, 감정, 상황태그, 메모 바텀시트 전부 칩 크기와 간격 수정

지출 입력을 완료 화면에서 감정과 상황 태그는 쉼표로 처리 / 상황태그와 메모는 | 처리

지출 등록 입력했을 때 홈 화면에서 날짜와 바로 밑에 지출 입력 정보의 간격이 더 좁을 것.

