### PR TITLE
[FIX] QA 수정사항 반영

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -227,3 +227,7 @@ img {
 .spending-swiper .swiper-pagination {
   display: none;
 }
+
+.picker-no-divider > div:last-child > div {
+  display: none !important;
+}

--- a/src/widgets/record/RecordContent.tsx
+++ b/src/widgets/record/RecordContent.tsx
@@ -357,7 +357,9 @@ export default function RecordContent() {
     const { year, month } = calendarMonth;
     const daysInMonth = getDaysInMonth(year, month);
     const firstDay = getFirstDayOfMonth(year, month);
-    const daysInPrevMonth = getDaysInMonth(year, month - 1);
+    const prevMonth = month === 1 ? 12 : month - 1;
+    const prevYear = month === 1 ? year - 1 : year;
+    const daysInPrevMonth = getDaysInMonth(prevYear, prevMonth);
 
     const days = [];
 
@@ -365,7 +367,7 @@ export default function RecordContent() {
       days.push({
         day: daysInPrevMonth - i,
         isCurrentMonth: false,
-        date: `${year}-${String(month - 1).padStart(2, '0')}-${String(daysInPrevMonth - i).padStart(2, '0')}`,
+        date: `${prevYear}-${String(prevMonth).padStart(2, '0')}-${String(daysInPrevMonth - i).padStart(2, '0')}`,
       });
     }
 

--- a/src/widgets/report/MonthPickerBottomSheet.tsx
+++ b/src/widgets/report/MonthPickerBottomSheet.tsx
@@ -168,7 +168,7 @@ export default function MonthPickerBottomSheet({
             wheelMode="natural"
             height={CONTAINER_HEIGHT}
             itemHeight={ITEM_HEIGHT}
-            className="bg-transparent!"
+            className="picker-no-divider bg-transparent!"
           >
             <Picker.Column name="year">
               {yearList.map((y, idx) => {

--- a/src/widgets/report/ReportEmpty.tsx
+++ b/src/widgets/report/ReportEmpty.tsx
@@ -2,47 +2,44 @@ const SECTIONS = [
   {
     id: 'category',
     title: '카테고리별 주요 지출 항목',
-    height: 'h-58.25',
-    pb: 'pb-19.75',
-    mt: 'mt-14.75',
+    boxClass: 'h-[233px] pb-[79px]',
+    messageGap: 'mt-[59px]',
     titleColor: 'text-[#030303]',
   },
   {
     id: 'emotion',
     title: '감정별 주요 지출 항목',
-    height: 'h-58.25',
-    pb: 'pb-19.75',
-    mt: 'mt-14.75',
+    boxClass: 'h-[233px] pb-[79px]',
+    messageGap: 'mt-[59px]',
     titleColor: 'text-[#030303]',
   },
   {
     id: 'situation',
     title: '자주 선택한 상황 태그',
-    height: 'h-70',
-    pb: 'pb-24.75',
-    mt: 'mt-21.5',
+    boxClass: 'h-[280px] pb-5',
+    messageGap: 'mt-[86px]',
     titleColor: 'text-[#1C1D1F]',
   },
 ];
 
 export default function ReportEmpty() {
   return (
-    <div className="flex flex-col gap-6.25">
+    <div className="flex flex-col gap-[25px]">
       {SECTIONS.map((section) => (
         <div
           key={section.id}
-          className={`flex ${section.height} w-full flex-col rounded-xl border border-[#F0F0F0] bg-[#F7F8FA] px-4 pt-5 ${section.pb}`}
+          className={`flex w-full flex-col rounded-xl border border-[#F0F0F0] bg-[#F7F8FA] px-4 pt-5 ${section.boxClass}`}
         >
           <p
-            className={`text-[20px] font-semibold leading-normal tracking-[-0.5px] ${section.titleColor}`}
+            className={`text-[20px] font-semibold leading-[150%] tracking-[-0.025em] ${section.titleColor}`}
           >
             {section.title}
           </p>
-          <div className={`${section.mt} flex flex-col items-center`}>
-            <p className="text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#73787E]">
+          <div className={`${section.messageGap} flex w-[216px] flex-col items-center self-center`}>
+            <p className="text-[16px] font-semibold leading-[150%] tracking-[-0.025em] text-[#73787E]">
               이번 달 소비가 아직 없어요
             </p>
-            <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#9FA4A8]">
+            <p className="text-[14px] font-medium leading-[150%] tracking-[-0.025em] text-[#9FA4A8]">
               소비를 기록하면 오늘을 돌아볼 수 있어요
             </p>
           </div>

--- a/src/widgets/retro/ChipSelect.tsx
+++ b/src/widgets/retro/ChipSelect.tsx
@@ -4,31 +4,26 @@ interface ChipSelectProps {
   options: string[];
   selected: string | null;
   onChange: (selected: string | null) => void;
-  columns?: number;
 }
 
 export default function ChipSelect({
   options,
   selected,
   onChange,
-  columns = 4,
 }: ChipSelectProps) {
   const handleClick = (option: string) => {
     onChange(selected === option ? null : option);
   };
 
   return (
-    <div
-      className="grid gap-1.5 px-4"
-      style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
-    >
+    <div className="mx-auto grid w-fit grid-cols-4 gap-1.5">
       {options.map((option) => {
         const isSelected = selected === option;
         return (
           <button
             key={option}
             onClick={() => handleClick(option)}
-            className={`flex h-8 items-center justify-center rounded-full border text-[14px] font-medium leading-normal tracking-[-0.35px] ${
+            className={`flex h-8 w-21 items-center justify-center rounded-full border text-[14px] font-medium leading-normal tracking-[-0.35px] ${
               isSelected
                 ? 'border-[#13278A] bg-[#ECF2FB] text-[#13278A]'
                 : 'border-[#E5E5E5] bg-white text-[#27282C]'

--- a/src/widgets/retro/ListSelect.tsx
+++ b/src/widgets/retro/ListSelect.tsx
@@ -19,10 +19,10 @@ export default function ListSelect({
           <button
             key={option}
             onClick={() => onChange(selected === option ? null : option)}
-            className={`flex h-13 items-center rounded-[10px] border px-4.5 text-[16px] font-medium leading-normal tracking-[-0.4px] ${
+            className={`flex h-13 w-89.5 max-w-full items-center rounded-[10px] border px-4.5 text-[16px] font-medium leading-normal tracking-[-0.4px] ${
               isSelected
                 ? 'border-[#13278A] bg-[#ECF2FB] text-[#13278A]'
-                : 'border-[#CACDD2] bg-white text-[#27282C]'
+                : 'border-[#E5E5E5] bg-white text-[#27282C]'
             }`}
           >
             {option}

--- a/src/widgets/retro/RetroMain.tsx
+++ b/src/widgets/retro/RetroMain.tsx
@@ -56,7 +56,7 @@ export default function RetroMain({
     <div className="flex w-full flex-col gap-5">
       <div className="relative flex h-90 w-full flex-col items-center rounded-[12px] bg-[#F7F8FA] px-5">
         <div className="mt-7.5 flex flex-col items-center gap-0.5">
-          <p className="whitespace-nowrap text-[18px] font-bold text-[#1C1D1F]">{mainMessage}</p>
+          <p className="whitespace-nowrap text-[18px] font-semibold text-[#1C1D1F]">{mainMessage}</p>
           <p className="whitespace-nowrap text-[14px] font-medium text-[#474C52]">{subMessage}</p>
         </div>
 
@@ -99,7 +99,7 @@ export default function RetroMain({
                 </p>
                 <div className="mt-1.5 flex items-center gap-1.5">
                   <EmotionIcon name={emotion.emotionName} size={25} />
-                  <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#1C1D1F]">
+                  <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#1C1D1F]">
                     {emotion.emotionName}
                   </p>
                 </div>


### PR DESCRIPTION
## 작업 내용                                                                        
                  
  - 월 피커 바텀시트의 회색 가로줄 제거                                                           
  - 빈 상태(`ReportEmpty`) 박스 크기·문구 위치 Figma 스펙 매칭
    - 박스 height(`233px` / `280px`), padding, 메시지 영역 width(`216px`), 박스 사이 gap(`25px`) 정확히 적용                                                           
                                                                                
  ### 가계부 기록                                                               
  - 캘린더 바텀시트에서 1월일 때 이전달 회색 날짜 클릭 시 "0월"로 표시되던 버그 수정
  (`prevYear`/`prevMonth` 분기 추가)                                                  
                                                                                      
  ### 회고                                                                            
  - 메인 페이지 그래프 타이틀 `font-bold` → `font-semibold`                           
  - 메인 페이지 감정 카드 텍스트 20px → 18px               
  - 만족도/내일 계획 문항(`ListSelect`) border 색 `#CACDD2` → `#E5E5E5` (Gray 2)      
  - 감정/상황 문항(`ChipSelect`)을 4열 그리드 + 84×32px 고정 폭으로 변경                                                                        
  - 만족도/내일 계획 버튼(`ListSelect`) 358×52px 고정 폭