### PR TITLE
[FIX] QA 수정사항

### DIFF
--- a/src/app/calendar/loading.tsx
+++ b/src/app/calendar/loading.tsx
@@ -1,0 +1,9 @@
+import PageHeader from '@/shared/ui/PageHeader';
+
+export default function Loading() {
+  return (
+    <div className="flex flex-1 flex-col">
+      <PageHeader title="캘린더" backHref="/" />
+    </div>
+  );
+}

--- a/src/app/report/category/[categoryId]/page.tsx
+++ b/src/app/report/category/[categoryId]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import CategoryDetailContent from '@/widgets/report/CategoryDetailContent';
+import PageHeader from '@/shared/ui/PageHeader';
 
 interface PageProps {
   params: Promise<{ categoryId: string }>;
@@ -8,7 +9,13 @@ interface PageProps {
 export default async function CategoryDetailPage({ params }: PageProps) {
   const { categoryId } = await params;
   return (
-    <Suspense fallback={<div>로딩중...</div>}>
+    <Suspense
+      fallback={
+        <div className="flex flex-1 flex-col bg-white">
+          <PageHeader title="카테고리별 지출 항목" />
+        </div>
+      }
+    >
       <CategoryDetailContent categoryId={categoryId} />
     </Suspense>
   );

--- a/src/app/report/emotion/[emotionId]/page.tsx
+++ b/src/app/report/emotion/[emotionId]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import EmotionDetailContent from '@/widgets/report/EmotionDetailContent';
+import PageHeader from '@/shared/ui/PageHeader';
 
 interface PageProps {
   params: Promise<{ emotionId: string }>;
@@ -8,7 +9,13 @@ interface PageProps {
 export default async function EmotionDetailPage({ params }: PageProps) {
   const { emotionId } = await params;
   return (
-    <Suspense fallback={<div>로딩중...</div>}>
+    <Suspense
+      fallback={
+        <div className="flex flex-1 flex-col bg-white">
+          <PageHeader title="감정별 지출 항목" />
+        </div>
+      }
+    >
       <EmotionDetailContent emotionId={emotionId} />
     </Suspense>
   );

--- a/src/app/report/monthly/page.tsx
+++ b/src/app/report/monthly/page.tsx
@@ -1,9 +1,16 @@
 import { Suspense } from 'react';
 import MonthlyExpenseContent from '@/widgets/report/MonthlyExpenseContent';
+import PageHeader from '@/shared/ui/PageHeader';
 
 export default function MonthlyExpensePage() {
   return (
-    <Suspense fallback={<div>로딩중...</div>}>
+    <Suspense
+      fallback={
+        <div className="flex flex-1 flex-col bg-white">
+          <PageHeader title="이번 달 지출" />
+        </div>
+      }
+    >
       <MonthlyExpenseContent />
     </Suspense>
   );

--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -79,7 +79,13 @@ export default function ReportPage() {
   const isLoadingData = !isMounted || !isLoaded || isLoading;
 
   return (
-    <Suspense fallback={<div>로딩중...</div>}>
+    <Suspense
+      fallback={
+        <div className="flex flex-1 flex-col bg-white">
+          <PageHeader title="리포트" showBack={false} />
+        </div>
+      }
+    >
       <ReportContent />
     </Suspense>
   );

--- a/src/app/retro/loading.tsx
+++ b/src/app/retro/loading.tsx
@@ -1,0 +1,9 @@
+import PageHeader from '@/shared/ui/PageHeader';
+
+export default function Loading() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-white">
+      <PageHeader title="회고하기" backHref="/" />
+    </div>
+  );
+}

--- a/src/app/retro/result/page.tsx
+++ b/src/app/retro/result/page.tsx
@@ -1,9 +1,16 @@
 import { Suspense } from 'react';
 import RetroResultContent from '@/widgets/retro/RetroResultContent';
+import PageHeader from '@/shared/ui/PageHeader';
 
 export default function RetroResultPage() {
   return (
-    <Suspense fallback={<div>로딩중...</div>}>
+    <Suspense
+      fallback={
+        <div className="flex flex-1 flex-col">
+          <PageHeader title="회고 결과" showBack={false} showClose closeHref="/retro" />
+        </div>
+      }
+    >
       <RetroResultContent />
     </Suspense>
   );

--- a/src/app/retro/survey/loading.tsx
+++ b/src/app/retro/survey/loading.tsx
@@ -1,0 +1,9 @@
+import PageHeader from '@/shared/ui/PageHeader';
+
+export default function Loading() {
+  return (
+    <div className="flex flex-1 flex-col">
+      <PageHeader title="회고하기" backHref="/retro" />
+    </div>
+  );
+}

--- a/src/entities/master-data/index.ts
+++ b/src/entities/master-data/index.ts
@@ -7,5 +7,6 @@ export {
   type Emotion,
   type SituationTag,
   type PaymentMethod,
+  type IncomeCategory,
 } from './model/master-data-schema';
 export { useMasterData } from './model/useMasterData';

--- a/src/entities/master-data/model/master-data-schema.ts
+++ b/src/entities/master-data/model/master-data-schema.ts
@@ -12,8 +12,8 @@ const CategoryGroupSchema = z.object({
 });
 
 const EmotionSchema = z.object({
-  id: z.number(),
-  name: z.string(),
+  emotionId: z.number(),
+  emotionName: z.string(),
 });
 
 const EmotionGroupSchema = z.object({
@@ -23,11 +23,16 @@ const EmotionGroupSchema = z.object({
 });
 
 const SituationTagSchema = z.object({
+  situationTagId: z.number(),
+  situationName: z.string(),
+});
+
+const PaymentMethodSchema = z.object({
   id: z.number(),
   name: z.string(),
 });
 
-const PaymentMethodSchema = z.object({
+const IncomeCategorySchema = z.object({
   id: z.number(),
   name: z.string(),
 });
@@ -37,6 +42,7 @@ export const MasterDataSchema = z.object({
   emotionGroups: z.array(EmotionGroupSchema),
   situationTags: z.array(SituationTagSchema),
   paymentMethods: z.array(PaymentMethodSchema),
+  incomeCategories: z.array(IncomeCategorySchema),
 });
 
 export type MasterData = z.infer<typeof MasterDataSchema>;
@@ -44,3 +50,4 @@ export type Category = z.infer<typeof CategorySchema>;
 export type Emotion = z.infer<typeof EmotionSchema>;
 export type SituationTag = z.infer<typeof SituationTagSchema>;
 export type PaymentMethod = z.infer<typeof PaymentMethodSchema>;
+export type IncomeCategory = z.infer<typeof IncomeCategorySchema>;

--- a/src/entities/master-data/model/useMasterData.ts
+++ b/src/entities/master-data/model/useMasterData.ts
@@ -34,6 +34,11 @@ interface PaymentMethod {
   id: number;
 }
 
+interface IncomeCategory {
+  label: string;
+  id: number;
+}
+
 function buildExpenseCategories(masterData?: MasterData): ExpenseCategory[] {
   if (!masterData?.categoryGroups) return [];
 
@@ -53,9 +58,9 @@ function buildEmotions(masterData?: MasterData): Emotion[] {
   return masterData.emotionGroups.map((group) => ({
     group: group.name,
     items: group.emotions.map((emotion) => ({
-      label: emotion.name,
-      emoji: EMOTION_SVG_MAP[emotion.id] || '',
-      id: emotion.id,
+      label: emotion.emotionName,
+      emoji: EMOTION_SVG_MAP[emotion.emotionId] || '',
+      id: emotion.emotionId,
     })),
   }));
 }
@@ -64,8 +69,8 @@ function buildSituationTags(masterData?: MasterData): SituationTag[] {
   if (!masterData?.situationTags) return [];
 
   return masterData.situationTags.map((tag): SituationTag => ({
-    label: tag.name,
-    id: tag.id,
+    label: tag.situationName,
+    id: tag.situationTagId,
   }));
 }
 
@@ -75,6 +80,15 @@ function buildPaymentMethods(masterData?: MasterData): PaymentMethod[] {
   return masterData.paymentMethods.map((method) => ({
     label: method.name,
     id: method.id,
+  }));
+}
+
+function buildIncomeCategories(masterData?: MasterData): IncomeCategory[] {
+  if (!masterData?.incomeCategories) return [];
+
+  return masterData.incomeCategories.map((category) => ({
+    label: category.name,
+    id: category.id,
   }));
 }
 
@@ -103,11 +117,17 @@ export function useMasterData() {
     [masterData],
   );
 
+  const incomeCategories = useMemo(
+    () => buildIncomeCategories(masterData),
+    [masterData],
+  );
+
   return {
     expenseCategories,
     emotions,
     situationTags,
     paymentMethods,
+    incomeCategories,
     masterData,
     isLoading,
   };

--- a/src/widgets/calendar/CalendarContent.tsx
+++ b/src/widgets/calendar/CalendarContent.tsx
@@ -13,35 +13,30 @@ import CalendarSkeleton from '@/widgets/calendar/CalendarSkeleton';
 import DateBottomSheet from '@/widgets/calendar/DateBottomSheet';
 import PageHeader from '@/shared/ui/PageHeader';
 
-const INCOME_CATEGORY_NAMES: Record<number, string> = {
-  1: '급여',
-  2: '용돈',
-  3: '부수입',
-  4: '상여금',
-  5: '금융수입',
-  6: '기타',
-};
-
 function buildLookups(masterData?: MasterData) {
   const categoryMap = new Map<number, string>();
   const emotionMap = new Map<number, string>();
   const situationMap = new Map<number, string>();
   const paymentMethodMap = new Map<number, string>();
+  const incomeCategoryMap = new Map<number, string>();
 
   masterData?.categoryGroups.forEach((g) =>
     g.categories.forEach((c) => categoryMap.set(c.id, c.name)),
   );
   masterData?.emotionGroups.forEach((g) =>
-    g.emotions.forEach((e) => emotionMap.set(e.id, e.name)),
+    g.emotions.forEach((e) => emotionMap.set(e.emotionId, e.emotionName)),
   );
   masterData?.situationTags.forEach((s) =>
-    situationMap.set(s.id, s.name),
+    situationMap.set(s.situationTagId, s.situationName),
   );
   masterData?.paymentMethods.forEach((p) =>
     paymentMethodMap.set(p.id, p.name),
   );
+  masterData?.incomeCategories.forEach((c) =>
+    incomeCategoryMap.set(c.id, c.name),
+  );
 
-  return { categoryMap, emotionMap, situationMap, paymentMethodMap };
+  return { categoryMap, emotionMap, situationMap, paymentMethodMap, incomeCategoryMap };
 }
 
 export default function CalendarContent() {
@@ -72,7 +67,7 @@ export default function CalendarContent() {
   const isLoading =
     !!token && (isExpensesLoading || isIncomesLoading || isMasterDataLoading);
 
-  const { categoryMap, emotionMap, situationMap, paymentMethodMap } = useMemo(
+  const { categoryMap, emotionMap, situationMap, paymentMethodMap, incomeCategoryMap } = useMemo(
     () => buildLookups(masterData),
     [masterData],
   );
@@ -122,7 +117,7 @@ export default function CalendarContent() {
         .filter((n): n is string => !!n),
     }));
     const incomeItems = dayIncomes.map((i) => ({
-      category: INCOME_CATEGORY_NAMES[i.incomeCategoryId] ?? '',
+      category: incomeCategoryMap.get(i.incomeCategoryId) ?? '',
       amount: i.amount,
       memo: i.memo ?? undefined,
     }));
@@ -137,6 +132,7 @@ export default function CalendarContent() {
     emotionMap,
     situationMap,
     paymentMethodMap,
+    incomeCategoryMap,
   ]);
 
   const handlePrevMonth = () => {

--- a/src/widgets/calendar/CalendarGrid.tsx
+++ b/src/widgets/calendar/CalendarGrid.tsx
@@ -60,6 +60,9 @@ function CalendarGrid({
   const isCurrentMonth =
     year === today.getFullYear() && month === today.getMonth();
   const todayDate = isCurrentMonth ? today.getDate() : -1;
+  const isFutureMonth =
+    year > today.getFullYear() ||
+    (year === today.getFullYear() && month > today.getMonth());
 
   const dates = getCalendarDates(year, month);
 
@@ -78,8 +81,13 @@ function CalendarGrid({
 
       <div className="grid flex-1 auto-rows-fr grid-cols-7">
         {dates.map((date, index) => {
-          const amounts = date.isCurrentMonth ? dailyAmounts[date.day] : undefined;
-          const isSelected = date.isCurrentMonth && date.day === selectedDay;
+          const isFutureDay =
+            date.isCurrentMonth &&
+            (isFutureMonth || (isCurrentMonth && date.day > todayDate));
+          const isInactive = !date.isCurrentMonth || isFutureDay;
+
+          const amounts = isInactive ? undefined : dailyAmounts[date.day];
+          const isSelected = !isInactive && date.day === selectedDay;
           const isToday = date.isCurrentMonth && date.day === todayDate;
           const otherDateSelected =
             selectedDay !== null && selectedDay !== todayDate;
@@ -91,18 +99,18 @@ function CalendarGrid({
             dayClass = 'rounded-[25px] bg-[#E5E5E5] text-[#1C1D1F]';
           } else if (isToday) {
             dayClass = 'rounded-[25px] bg-[#13278A] text-white';
-          } else if (date.isCurrentMonth) {
-            dayClass = 'text-[#1C1D1F]';
-          } else {
+          } else if (isInactive) {
             dayClass = 'text-[#9FA4A8]';
+          } else {
+            dayClass = 'text-[#1C1D1F]';
           }
 
           return (
             <div
               key={index}
-              onClick={() => date.isCurrentMonth && onDateClick?.(date.day)}
+              onClick={() => !isInactive && onDateClick?.(date.day)}
               className={`flex flex-col items-start gap-2.5 px-1.25 py-2 ${
-                date.isCurrentMonth ? 'cursor-pointer' : ''
+                !isInactive ? 'cursor-pointer' : ''
               }`}
             >
               <div

--- a/src/widgets/report/CategoryChart.tsx
+++ b/src/widgets/report/CategoryChart.tsx
@@ -32,11 +32,9 @@ function DonutChart({ categories }: { categories: CategoryChartCategory[] }) {
     return { ...cat, startDeg, segDeg, dashStartDeg: startDeg, dashDeg: segDeg };
   });
 
-  // 1위 segment의 1/3 지점에 떠있는 라벨 배치
+  // 1위 라벨은 항상 9시 방향(왼쪽 가운데)에 고정
   const topSegment = segments[0];
-  const topMidDeg = topSegment
-    ? topSegment.startDeg + topSegment.segDeg / 3
-    : 0;
+  const topMidDeg = 90;
   const topMidRad = (topMidDeg * Math.PI) / 180;
   const containerPx = 198;
   const center = containerPx / 2;

--- a/src/widgets/retro/RetroMain.tsx
+++ b/src/widgets/retro/RetroMain.tsx
@@ -42,7 +42,7 @@ export default function RetroMain({
           },
         ]
       : []),
-  ].slice(0, 3);
+  ].slice(0, 2);
 
   const maxAmount = Math.max(...barItems.map((b) => b.amount), 1);
 


### PR DESCRIPTION
## 작업 내용                                                                                                                               
                                                                                                                                             
  ### 로딩 처리                                                                                                                              
  - 라우트 진입 시 헤더 placeholder fallback 적용
  - "로딩중..." 텍스트 fallback 모두 PageHeader-only 컴포넌트로 교체                                        
  - `app/{route}/loading.tsx`                                                                                         
                                                                                
  ### 마스터데이터 정리                                                                                                                      
  - 백엔드 master-data 응답에 `incomeCategories` 추가 → 캘린더 `INCOME_CATEGORY_NAMES` 하드코딩 제거하고 master-data 매핑으로 교체
                                                                                                                                             
  ### 회고 메인 그래프                                                                                                                       
  - 막대 최대 개수 3개 → 2개로 제한                                                                                    
                                                                                                                                             
  ### 캘린더                                                                                                                                 
  - 오늘 이후 날짜 셀 회색 처리 + 클릭/바텀시트 비활성화                                                                                     
                                                        
  ### 카테고리 도넛 차트                                                                                                                     
  - 1위 카테고리 라벨을 9시 방향(왼쪽 가운데)에 고정