### PR TITLE
[FIX] 회고 그래프 secondCategories 응답 대응 작업

### DIFF
--- a/src/entities/report/model/report-schema.ts
+++ b/src/entities/report/model/report-schema.ts
@@ -150,8 +150,9 @@ const DailyExpenseGraphSchema = z.object({
   subMessage: z.string(),
   topRatio: z.number(),
   topCategories: z.array(DailyTopCategorySchema),
-  secondCategory: DailyTopCategorySchema.nullable(),
-  extraCount: z.number(),
+  secondCategories: z.array(DailyTopCategorySchema).optional().default([]),
+  topExtraCount: z.number().optional().default(0),
+  secondExtraCount: z.number().optional().default(0),
 });
 
 const DailyEmotionItemSchema = z.object({

--- a/src/widgets/retro/RetroMain.tsx
+++ b/src/widgets/retro/RetroMain.tsx
@@ -21,28 +21,43 @@ export default function RetroMain({
   const router = useRouter();
   const [emblaRef] = useEmblaCarousel({ align: 'start', dragFree: true });
 
-  const { mainMessage, subMessage, topCategories, secondCategory, extraCount } =
-    expenseGraph;
+  const {
+    mainMessage,
+    subMessage,
+    topCategories,
+    secondCategories = [],
+    topExtraCount = 0,
+    secondExtraCount = 0,
+  } = expenseGraph;
+
+  const topAmount = topCategories[0]?.amount ?? 0;
+  const secondAmount = secondCategories[0]?.amount ?? 0;
+
+  const joinLabels = (items: { label: string }[]) =>
+    items.map((c) => c.label).join(', ');
+
+  const topLabel =
+    topCategories.length > 0
+      ? topExtraCount > 0
+        ? `${joinLabels(topCategories)} 외 ${topExtraCount}개`
+        : joinLabels(topCategories)
+      : '';
+
+  const secondLabel =
+    secondCategories.length > 0
+      ? secondExtraCount > 0
+        ? `${joinLabels(secondCategories)} 외 ${secondExtraCount}개`
+        : joinLabels(secondCategories)
+      : '';
 
   const barItems = [
-    ...topCategories.slice(0, 2).map((c) => ({
-      label: c.label,
-      amount: c.amount,
-      isTop: true,
-    })),
-    ...(secondCategory && topCategories.length === 1
-      ? [{ label: secondCategory.label, amount: secondCategory.amount, isTop: false }]
+    ...(topCategories.length > 0
+      ? [{ label: topLabel, amount: topAmount, isTop: true }]
       : []),
-    ...(extraCount > 0
-      ? [
-          {
-            label: `외 ${extraCount}개`,
-            amount: topCategories[0]?.amount ?? 0,
-            isTop: false,
-          },
-        ]
+    ...(secondCategories.length > 0
+      ? [{ label: secondLabel, amount: secondAmount, isTop: secondCategories.length > 1 }]
       : []),
-  ].slice(0, 3);
+  ];
 
   const maxAmount = Math.max(...barItems.map((b) => b.amount), 1);
 


### PR DESCRIPTION
## 작업 내용                                                                                                                               
                                                                                                                                             
  ### `entities/report/model/report-schema.ts`                                  
  - `DailyExpenseGraphSchema`에 `secondCategories`, `topExtraCount`, `secondExtraCount` 필드 추가                                                                                              
                                                                                                                                             
  ### `widgets/retro/RetroMain.tsx`                                                                                                          
  - `barItems` 로직 재작성 (1위/2위 막대 각 1개, 최대 2개)                                                                                   
  - 라벨 정책 적용                                                              
    - 단일: `식비`                                                                                                                           
    - 동률 N개: `식비, 카페`                                                                                                                 
    - 3개 이상 동률: `식비, 카페 외 N개`                                                                                                     
  - 2위가 동률(`secondCategories.length > 1`)이면 1등과 동일한 강조 색(파란색) 적용