### PR TITLE
[FIX] 날짜 처리 KST timezone 보정

### DIFF
--- a/src/shared/ui/house-hold/TodayExpenseBox.tsx
+++ b/src/shared/ui/house-hold/TodayExpenseBox.tsx
@@ -11,13 +11,6 @@ import { useMasterData } from '@/entities/master-data';
 import { useToken, useUser } from '@/shared/store';
 import ConfirmModal from '@/shared/ui/ConfirmModal';
 
-const TODAY = new Date();
-const MIN_DATE = (() => {
-  const date = new Date(TODAY);
-  date.setMonth(date.getMonth() - 1);
-  return date;
-})();
-
 interface TodayExpenseBoxProps {
   emotions: any[];
   expenseCategories: any[];
@@ -25,6 +18,12 @@ interface TodayExpenseBoxProps {
 
 export default function TodayExpenseBox({ emotions, expenseCategories }: TodayExpenseBoxProps) {
   const router = useRouter();
+  const [TODAY] = useState(() => new Date());
+  const MIN_DATE = useMemo(() => {
+    const date = new Date(TODAY);
+    date.setMonth(date.getMonth() - 1);
+    return date;
+  }, [TODAY]);
   const [selectedDate, setSelectedDate] = useState<Date>(TODAY);
   const [showLoginModal, setShowLoginModal] = useState(false);
   const { getUser } = useUser();

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -4,6 +4,18 @@
  */
 
 /**
+ * 로컬 timezone(KST) 기준 오늘 날짜를 YYYY-MM-DD 형식으로 반환
+ * `toISOString()`은 UTC 기준이라 KST 새벽 시간대에 어제 날짜가 나오는 버그 방지
+ */
+export function todayKST(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
  * 서버-클라이언트 안전한 날짜 포맷팅
  * 서버에서는 ISO 문자열 반환, 클라이언트에서만 로컬 포맷 적용
  */

--- a/src/widgets/export/ExportContent.tsx
+++ b/src/widgets/export/ExportContent.tsx
@@ -11,6 +11,7 @@ import { useDailyExpend } from '@/entities/daily-expend/model/useDailyExpend';
 import { DailyExpendType } from '@/entities/daily-expend/model/daily-expend-type';
 import { useMasterData } from '@/entities/master-data';
 import { useDeleteExpense } from '@/features/delete-expense/model/useDeleteExpense';
+import { todayKST } from '@/shared/utils/date';
 import { Trash2 } from 'lucide-react';
 
 type SortType = 'latest' | 'oldest' | 'expensive' | 'cheap';
@@ -44,7 +45,7 @@ export default function ExportContent() {
 
   const touchStartX = useRef(0);
 
-  const selectedDate = searchParams?.get('date') || new Date().toISOString().split('T')[0];
+  const selectedDate = searchParams?.get('date') || todayKST();
   const [year, month, day] = selectedDate.split('-').map(Number);
 
   const { data = [], isLoading } = useDailyExpend(year, month, day);

--- a/src/widgets/house-hold/HouseHoldBoxWrapper.tsx
+++ b/src/widgets/house-hold/HouseHoldBoxWrapper.tsx
@@ -14,9 +14,10 @@ import { useWeekExpend } from '@/entities/week-expenditure/model/useWeekExpend';
 import { useToken, useUser } from '@/shared/store';
 import { useMasterData } from '@/entities/master-data';
 import { useMemo } from 'react';
+import { todayKST } from '@/shared/utils/date';
 
 const getRandomNumberByDate = (): number => {
-  const today = new Date().toISOString().split('T')[0];
+  const today = todayKST();
   let hash = 0;
   for (let i = 0; i < today.length; i++) {
     hash = today.charCodeAt(i) + ((hash << 5) - hash);


### PR DESCRIPTION
## 작업 내용                                                                                                                               
                                                                                
  ### `shared/utils/date.ts`                                                                                                                 
  - `todayKST()` helper 신설 — `getFullYear/getMonth/getDate` 기반으로 로컬 timezone(KST) 기준 YYYY-MM-DD 반환                               
                                                                                                                                             
  ### `widgets/house-hold/HouseHoldBoxWrapper.tsx`                                                                                           
  - `new Date().toISOString().split('T')[0]` → `todayKST()`                                                                                  
                                                                                                                                             
  ### `widgets/export/ExportContent.tsx`                                       
  - 오늘의 지출 default 날짜를 `todayKST()`로 교체                                                                                           
                                                  
  ### `shared/ui/house-hold/TodayExpenseBox.tsx`                                                                                             
  - 모듈 레벨 상수 `TODAY = new Date()`, `MIN_DATE` → 컴포넌트 내부 `useState(() => new Date())` + `useMemo`로 이동                          
  - 모듈 캐싱으로 dev 서버가 자정 넘어가도 today가 갱신 안 되던 문제 해결                                          
  - 마운트 시점마다 새로 계산