### PR TITLE
[FIX] 지출 등록 시 expenseTime을 현재 시각으로 저장

### DIFF
--- a/src/widgets/record/RecordContent.tsx
+++ b/src/widgets/record/RecordContent.tsx
@@ -437,8 +437,8 @@ export default function RecordContent() {
     return days;
   };
 
-  const date = new Date(record.date);
-  const hhmm = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}:${String(date.getSeconds()).padStart(2, '0')}`;
+  const nowForTime = new Date();
+  const hhmm = `${String(nowForTime.getHours()).padStart(2, '0')}:${String(nowForTime.getMinutes()).padStart(2, '0')}:${String(nowForTime.getSeconds()).padStart(2, '0')}`;
 
   // API 호출
   const { mutate: houseHoldPost } = useHouseHoldPost('expense', {


### PR DESCRIPTION
## 문제                                                                                                                                    
  지출 등록 시 모든 항목의 `expenseTime`이 `"09:00:00"`으로 동일하게 저장되어, 오늘의 지출 페이지의 "오래된순" 정렬이 의미 없이 동작하던 버그                                                                                                                                 
                                                                                                                                             
  ## 원인                                                                                                                                    
  `RecordContent.tsx:440-441`                                                                                                                
                                                                                                                                             
  ```ts                                                                                                                                      
  const date = new Date(record.date);  // record.date = "2026-05-08"                                                                         
  const hhmm = `${String(date.getHours())...`;                                                                                               
  ```                                                                                                                                        
                                        
  `new Date("2026-05-08")`은 **UTC 자정**으로 파싱되고, `getHours()`는 KST(+9)로 변환되어 항상 `"09:00:00"` 반환.
                                                                                                                                             
  ## 수정                               
  `record.date` 기반이 아닌 **현재 시각(`new Date()`)** 기준으로 `hhmm` 생성                                                                
                                                                                                                                             
  ```ts                                                                         
  const nowForTime = new Date();                                                                                                             
  const hhmm = `${String(nowForTime.getHours()).padStart(2, '0')}:...`;
  ```                                                                                                                                        
                                                                                
  ## 영향                                                                                                                                    
  - 새로 등록되는 지출은 정확한 등록 시각으로 저장
  - 오늘의 지출 페이지 "오래된순" / "최신순" 정렬이 의미 있게 동작