### PR TITLE
[FIX] 자산 페이지 OLDEST 정렬 옵션 적용

### DIFF
--- a/src/entities/get-assets/get-assets-api.ts
+++ b/src/entities/get-assets/get-assets-api.ts
@@ -2,7 +2,7 @@ import { apiClient } from '@/shared/api/api-instance';
 
 export interface GetAssetsParams {
   categoryId?: number;
-  sort?: 'LATEST' | 'AMOUNT_ASC' | 'AMOUNT_DESC';
+  sort?: 'LATEST' | 'OLDEST' | 'AMOUNT_ASC' | 'AMOUNT_DESC';
   page?: number;
   size?: number;
 }

--- a/src/entities/get-assets/useGetAssets.ts
+++ b/src/entities/get-assets/useGetAssets.ts
@@ -98,6 +98,8 @@ function applySorting(assets: AssetItem[], sort?: string): AssetItem[] {
     sorted.sort((a, b) => b.amount - a.amount);
   } else if (sort === 'AMOUNT_ASC') {
     sorted.sort((a, b) => a.amount - b.amount);
+  } else if (sort === 'OLDEST') {
+    sorted.sort((a, b) => new Date(a.assetDate).getTime() - new Date(b.assetDate).getTime());
   } else {
     // LATEST (최신순) - assetDate 역순
     sorted.sort((a, b) => new Date(b.assetDate).getTime() - new Date(a.assetDate).getTime());

--- a/src/widgets/asset/AssetContent.tsx
+++ b/src/widgets/asset/AssetContent.tsx
@@ -9,11 +9,11 @@ import ConfirmModal from '@/shared/ui/ConfirmModal';
 import { useGetAssets } from '@/entities/get-assets/useGetAssets';
 import { useUser } from '@/shared/store';
 
-const SORT_MAPPING: Record<SortType, 'LATEST' | 'AMOUNT_ASC' | 'AMOUNT_DESC'> = {
+const SORT_MAPPING: Record<SortType, 'LATEST' | 'OLDEST' | 'AMOUNT_ASC' | 'AMOUNT_DESC'> = {
   latest: 'LATEST',
   expensive: 'AMOUNT_DESC',
   cheap: 'AMOUNT_ASC',
-  oldest: 'LATEST',
+  oldest: 'OLDEST',
 };
 
 export default function AssetContent() {

--- a/src/widgets/asset/AssetDetailContent.tsx
+++ b/src/widgets/asset/AssetDetailContent.tsx
@@ -25,11 +25,11 @@ const CATEGORY_ID_MAP: Record<string, number> = {
   etc: 6,
 };
 
-const SORT_MAPPING: Record<SortType, 'LATEST' | 'AMOUNT_ASC' | 'AMOUNT_DESC'> = {
+const SORT_MAPPING: Record<SortType, 'LATEST' | 'OLDEST' | 'AMOUNT_ASC' | 'AMOUNT_DESC'> = {
   latest: 'LATEST',
   expensive: 'AMOUNT_DESC',
   cheap: 'AMOUNT_ASC',
-  oldest: 'LATEST',
+  oldest: 'OLDEST',
 };
 
 const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'] as const;


### PR DESCRIPTION

  ## 작업 내용

  ### `widgets/asset/AssetContent.tsx`
  - `SORT_MAPPING.oldest`: `'LATEST'` → `'OLDEST'`
  - 타입 시그니처에 `'OLDEST'` 추가

  ### `widgets/asset/AssetDetailContent.tsx`
  - 동일 변경

  ### `entities/get-assets/get-assets-api.ts`
  - `GetAssetsParams.sort` 타입에 `'OLDEST'` 추가

  ### `entities/get-assets/useGetAssets.ts`
  - `applySorting`에 `OLDEST` 케이스 추가 (`assetDate` 오름차순 정렬)