### PR TITLE
[FIX] 회고 그래프 막대 색상 변경

### DIFF
--- a/src/widgets/retro/RetroMain.tsx
+++ b/src/widgets/retro/RetroMain.tsx
@@ -55,7 +55,7 @@ export default function RetroMain({
       ? [{ label: topLabel, amount: topAmount, isTop: true }]
       : []),
     ...(secondCategories.length > 0
-      ? [{ label: secondLabel, amount: secondAmount, isTop: secondCategories.length > 1 }]
+      ? [{ label: secondLabel, amount: secondAmount, isTop: false }]
       : []),
   ].slice(0, 2);
 


### PR DESCRIPTION
  ## 문제                                                                             
  회고 메인 그래프에서 2위가 동률(secondCategories 여러 개)일 때 1위와 동일한         
  파란색으로 표시되어, 비율이 다른데도 색이 같아 시각적으로 구분이 안 되는 이슈.      
                                                                                
  ## 변경                                                                             
  `widgets/retro/RetroMain.tsx:58`                                                    
                                                                                      
  - `isTop: secondCategories.length > 1` → `isTop: false`                             
  - 2위 막대는 동률 여부와 무관하게 항상 회색(`#CACDD2`)으로 표시              
  - 1위 막대는 그대로 파란색(`#6B9CE5`) 유지