### PR TITLE
[FEAT] 캘린더 바텀시트 수입/지출 수정·삭제 기능

### DIFF
--- a/src/entities/income/model/income-schema.ts
+++ b/src/entities/income/model/income-schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 export const IncomeSchema = z.object({
+  incomeId: z.number(),
   userId: z.number(),
   amount: z.number(),
   incomeCategoryId: z.number(),

--- a/src/features/delete-expense/model/useDeleteExpense.ts
+++ b/src/features/delete-expense/model/useDeleteExpense.ts
@@ -1,5 +1,6 @@
 import { deleteExpenseApi } from '@/features/delete-expense/api/delete-expense-api';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { expenseQueries } from '@/entities/expense';
 
 export function useDeleteExpense(year: number, month: number, day: number) {
   const queryClient = useQueryClient();
@@ -7,9 +8,14 @@ export function useDeleteExpense(year: number, month: number, day: number) {
   const mutation = useMutation<void, unknown, number>({
     mutationFn: (expenseId: number) => deleteExpenseApi(expenseId),
     onSuccess: async () => {
-      await queryClient.refetchQueries({
-        queryKey: ['daily-expend', year, month, day],
-      });
+      await Promise.all([
+        queryClient.refetchQueries({
+          queryKey: ['daily-expend', year, month, day],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: expenseQueries.monthly('', year, month).queryKey,
+        }),
+      ]);
     },
     onError: (error: unknown) => {
       console.error('삭제 실패:', error);

--- a/src/features/delete-income/api/delete-income-api.ts
+++ b/src/features/delete-income/api/delete-income-api.ts
@@ -1,0 +1,5 @@
+import { apiClient } from '@/shared/api/api-instance';
+
+export function deleteIncomeApi(incomeId: number) {
+  return apiClient<void>(`/api/v1/incomes/${incomeId}`, { method: 'DELETE' });
+}

--- a/src/features/delete-income/model/useDeleteIncome.ts
+++ b/src/features/delete-income/model/useDeleteIncome.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteIncomeApi } from '@/features/delete-income/api/delete-income-api';
+import { incomeQueries } from '@/entities/income';
+
+export function useDeleteIncome(year: number, month: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, unknown, number>({
+    mutationFn: (incomeId: number) => deleteIncomeApi(incomeId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: incomeQueries.monthly('', year, month).queryKey,
+      });
+    },
+    onError: (error: unknown) => {
+      console.error('수입 삭제 실패:', error);
+    },
+  });
+}

--- a/src/features/update-income/api/update-income-api.ts
+++ b/src/features/update-income/api/update-income-api.ts
@@ -1,0 +1,16 @@
+import { apiClient } from '@/shared/api/api-instance';
+
+export interface UpdateIncomeRequest {
+  amount: number;
+  incomeCategoryId: number;
+  incomeDate: string;
+  memo?: string;
+}
+
+export function updateIncomeApi(incomeId: number, body: UpdateIncomeRequest) {
+  return apiClient<void>(`/api/v1/incomes/${incomeId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}

--- a/src/features/update-income/model/useUpdateIncome.ts
+++ b/src/features/update-income/model/useUpdateIncome.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  updateIncomeApi,
+  type UpdateIncomeRequest,
+} from '@/features/update-income/api/update-income-api';
+import { incomeQueries } from '@/entities/income';
+
+interface UpdateIncomeArgs {
+  incomeId: number;
+  body: UpdateIncomeRequest;
+  year: number;
+  month: number;
+}
+
+export function useUpdateIncome() {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, unknown, UpdateIncomeArgs>({
+    mutationFn: ({ incomeId, body }) => updateIncomeApi(incomeId, body),
+    onSuccess: async (_data, { year, month }) => {
+      await queryClient.invalidateQueries({
+        queryKey: incomeQueries.monthly('', year, month).queryKey,
+      });
+    },
+    onError: (error: unknown) => {
+      console.error('수입 수정 실패:', error);
+    },
+  });
+}

--- a/src/widgets/calendar/CalendarContent.tsx
+++ b/src/widgets/calendar/CalendarContent.tsx
@@ -117,6 +117,7 @@ export default function CalendarContent() {
       (i) => Number(i.incomeDate.split('-')[2]) === selectedDay,
     );
     const expenseItems = dayExpenses.map((e) => ({
+      id: e.expenseId,
       category: categoryMap.get(e.categoryId) ?? '',
       tags: e.situationTagIds
         .map((id) => situationMap.get(id))
@@ -129,6 +130,7 @@ export default function CalendarContent() {
         .filter((n): n is string => !!n),
     }));
     const incomeItems = dayIncomes.map((i) => ({
+      id: i.incomeId,
       category: incomeCategoryMap.get(i.incomeCategoryId) ?? '',
       amount: i.amount,
       memo: i.memo ?? undefined,

--- a/src/widgets/calendar/DateBottomSheet.tsx
+++ b/src/widgets/calendar/DateBottomSheet.tsx
@@ -1,10 +1,16 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Trash2 } from 'lucide-react';
 import EmotionIcon from '@/shared/ui/EmotionIcon';
+import ConfirmModal from '@/shared/ui/ConfirmModal';
 import TransactionTypeButton, { TransactionType } from '@/shared/ui/TransactionTypeButton';
+import { useDeleteExpense } from '@/features/delete-expense/model/useDeleteExpense';
+import { useDeleteIncome } from '@/features/delete-income/model/useDeleteIncome';
 
 interface ExpenseItem {
+  id: number;
   category: string;
   tags: string[];
   amount: number;
@@ -14,10 +20,14 @@ interface ExpenseItem {
 }
 
 interface IncomeItem {
+  id: number;
   category: string;
   amount: number;
   memo?: string;
 }
+
+type DeleteTarget = { type: 'expense' | 'income'; id: number } | null;
+type SwipedTarget = { type: 'expense' | 'income'; id: number } | null;
 
 function EmptyRecord({ type }: { type: TransactionType }) {
   const isIncome = type === 'income';
@@ -54,9 +64,18 @@ export default function DateBottomSheet({
   incomeItems,
   onClose,
 }: DayDetailSheetProps) {
+  const router = useRouter();
   const [isClosing, setIsClosing] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [transactionType, setTransactionType] = useState<TransactionType>('expense');
+  const [swipedTarget, setSwipedTarget] = useState<SwipedTarget>(null);
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget>(null);
+  const touchStartX = useRef(0);
+
+  const dateString = `${year}-${String(month + 1).padStart(2, '0')}-${String(date).padStart(2, '0')}`;
+
+  const deleteExpenseMutation = useDeleteExpense(year, month + 1, date);
+  const deleteIncomeMutation = useDeleteIncome(year, month + 1);
 
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -73,11 +92,59 @@ export default function DateBottomSheet({
     }, 300);
   };
 
+  const handlePointerDown = (e: React.PointerEvent) => {
+    touchStartX.current = e.clientX;
+  };
+
+  const handlePointerUp = (
+    e: React.PointerEvent,
+    type: 'expense' | 'income',
+    id: number,
+  ) => {
+    const diff = touchStartX.current - e.clientX;
+    if (diff > 30) {
+      setSwipedTarget({ type, id });
+      e.preventDefault();
+    } else if (diff < -30) {
+      setSwipedTarget(null);
+    }
+  };
+
+  const handleItemClick = (
+    e: React.MouseEvent,
+    type: 'expense' | 'income',
+    id: number,
+  ) => {
+    const diff = Math.abs(touchStartX.current - e.clientX);
+    if (diff >= 30) return;
+    if (type === 'expense') {
+      router.push(`/record?expenseId=${id}&date=${dateString}&mode=edit`);
+    } else {
+      router.push(`/record?incomeId=${id}&date=${dateString}&mode=edit`);
+    }
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!deleteTarget) return;
+    const reset = () => {
+      setDeleteTarget(null);
+      setSwipedTarget(null);
+    };
+    if (deleteTarget.type === 'expense') {
+      deleteExpenseMutation.mutate(deleteTarget.id, { onSuccess: reset });
+    } else {
+      deleteIncomeMutation.mutate(deleteTarget.id, { onSuccess: reset });
+    }
+  };
+
   const dayOfWeek = ['일', '월', '화', '수', '목', '금', '토'][
     new Date(year, month, date).getDay()
   ];
   const dateLabel = `${month + 1}월 ${date}일 ${dayOfWeek}요일`;
   const isEmpty = expenseItems.length === 0 && income === 0 && expense === 0;
+
+  const isSwiped = (type: 'expense' | 'income', id: number) =>
+    swipedTarget?.type === type && swipedTarget.id === id;
 
   return (
     <div
@@ -115,7 +182,6 @@ export default function DateBottomSheet({
           </>
         ) : (
           <>
-
             <button
               onClick={handleClose}
               className="absolute right-4 top-3.5"
@@ -123,114 +189,176 @@ export default function DateBottomSheet({
             >
               <img src="/svg/icon_X_dark.svg" alt="" width={28} height={28} />
             </button>
-          <div className="flex flex-col gap-5 overflow-y-auto">
-            <div className="flex flex-col gap-5">
-              <div className="flex flex-col gap-1.25 px-4">
-                <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
-                  수입
-                </p>
-                <p className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#030303]">
-                  {income.toLocaleString()}원
-                </p>
+            <div className="flex flex-col gap-5 overflow-y-auto">
+              <div className="flex flex-col gap-5">
+                <div className="flex flex-col gap-1.25 px-4">
+                  <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
+                    수입
+                  </p>
+                  <p className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#030303]">
+                    {income.toLocaleString()}원
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-1.25 border-b border-[#E5E5E5] px-4 pb-3.75">
+                  <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
+                    지출
+                  </p>
+                  <p className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#EB1C1C]">
+                    {expense.toLocaleString()}원
+                  </p>
+                </div>
               </div>
 
-              <div className="flex flex-col gap-1.25 border-b border-[#E5E5E5] px-4 pb-3.75">
-                <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
-                  지출
+              <div className="flex flex-col gap-2.5 px-4">
+                <TransactionTypeButton type={transactionType} onTypeChange={setTransactionType} />
+                <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#73787E]">
+                  {dateLabel}
                 </p>
-                <p className="text-[24px] font-semibold leading-normal tracking-[-0.6px] text-[#EB1C1C]">
-                  {expense.toLocaleString()}원
-                </p>
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-2.5 px-4">
-              <TransactionTypeButton type={transactionType} onTypeChange={setTransactionType} />
-              <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#73787E]">
-                {dateLabel}
-              </p>
-              {transactionType === 'income' ? (
-                incomeItems.length === 0 ? (
+                {transactionType === 'income' ? (
+                  incomeItems.length === 0 ? (
+                    <div className="flex flex-1 flex-col items-center justify-center py-20">
+                      <EmptyRecord type="income" />
+                    </div>
+                  ) : (
+                    <div className="flex flex-col gap-5">
+                      {incomeItems.map((item) => (
+                        <div
+                          key={item.id}
+                          className="relative overflow-hidden rounded-lg"
+                          onPointerDown={handlePointerDown}
+                          onPointerUp={(e) => handlePointerUp(e, 'income', item.id)}
+                          style={{ touchAction: 'pan-y' }}
+                        >
+                          <div className="absolute inset-y-0 right-0 z-0 flex items-center justify-end pr-4">
+                            <button
+                              onClick={() => setDeleteTarget({ type: 'income', id: item.id })}
+                              className="flex h-10 w-10 items-center justify-center rounded-full bg-[#EB1C1C] text-white"
+                              aria-label="삭제"
+                            >
+                              <Trash2 size={20} />
+                            </button>
+                          </div>
+                          <div
+                            role="button"
+                            tabIndex={0}
+                            onClick={(e) => handleItemClick(e, 'income', item.id)}
+                            className={`relative z-10 flex min-h-12 cursor-pointer flex-col justify-center gap-0.75 bg-white transition-transform duration-300 ${
+                              isSwiped('income', item.id) ? 'translate-x-[-80px]' : ''
+                            }`}
+                          >
+                            <div className="flex items-center justify-between">
+                              <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
+                                {item.category}
+                              </p>
+                              <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
+                                {item.amount.toLocaleString()}원
+                              </p>
+                            </div>
+                            {item.memo && (
+                              <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+                                {item.memo}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )
+                ) : expenseItems.length === 0 ? (
                   <div className="flex flex-1 flex-col items-center justify-center py-20">
-                    <EmptyRecord type="income" />
+                    <EmptyRecord type="expense" />
                   </div>
                 ) : (
                   <div className="flex flex-col gap-5">
-                    {incomeItems.map((item, index) => (
-                      <div key={index} className="flex flex-col gap-0.75">
-                        <div className="flex items-center justify-between">
-                          <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
-                            {item.category}
-                          </p>
-                          <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
-                            {item.amount.toLocaleString()}원
-                          </p>
+                    {expenseItems.map((item) => (
+                      <div
+                        key={item.id}
+                        className="relative overflow-hidden rounded-lg"
+                        onPointerDown={handlePointerDown}
+                        onPointerUp={(e) => handlePointerUp(e, 'expense', item.id)}
+                        style={{ touchAction: 'pan-y' }}
+                      >
+                        <div className="absolute inset-y-0 right-0 z-0 flex items-center justify-end pr-4">
+                          <button
+                            onClick={() => setDeleteTarget({ type: 'expense', id: item.id })}
+                            className="flex h-10 w-10 items-center justify-center rounded-full bg-[#EB1C1C] text-white"
+                            aria-label="삭제"
+                          >
+                            <Trash2 size={20} />
+                          </button>
                         </div>
-                        {item.memo && (
-                          <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
-                            {item.memo}
-                          </p>
-                        )}
+                        <div
+                          role="button"
+                          tabIndex={0}
+                          onClick={(e) => handleItemClick(e, 'expense', item.id)}
+                          className={`relative z-10 flex cursor-pointer flex-col gap-0.75 bg-white transition-transform duration-300 ${
+                            isSwiped('expense', item.id) ? 'translate-x-[-80px]' : ''
+                          }`}
+                        >
+                          <div className="flex items-center justify-between">
+                            <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
+                              {item.category}
+                            </p>
+                            <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
+                              {item.amount.toLocaleString()}원
+                            </p>
+                          </div>
+
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-2">
+                              <div className="flex items-center gap-1.5">
+                                {item.tags.map((tag) => (
+                                  <span
+                                    key={tag}
+                                    className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#13278A]"
+                                  >
+                                    #{tag}
+                                  </span>
+                                ))}
+                              </div>
+                              {item.emotions && item.emotions.length > 0 && (
+                                <>
+                                  <span className="h-3.5 w-px bg-[#E5E5E5]" />
+                                  <div className="flex items-center gap-1.5">
+                                    {item.emotions.map((emotion) => (
+                                      <EmotionIcon key={emotion} name={emotion} size={24} />
+                                    ))}
+                                  </div>
+                                </>
+                              )}
+                            </div>
+                            <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+                              {item.paymentMethod}
+                            </p>
+                          </div>
+
+                          {item.memo && (
+                            <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
+                              {item.memo}
+                            </p>
+                          )}
+                        </div>
                       </div>
                     ))}
                   </div>
-                )
-              ) : (
-                <div className="flex flex-col gap-5">
-                  {expenseItems.map((item, index) => (
-                    <div key={index} className="flex flex-col gap-0.75">
-
-                      <div className="flex items-center justify-between">
-                        <p className="text-[18px] font-semibold leading-normal tracking-[-0.45px] text-[#27282C]">
-                          {item.category}
-                        </p>
-                        <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
-                          {item.amount.toLocaleString()}원
-                        </p>
-                      </div>
-
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <div className="flex items-center gap-1.5">
-                            {item.tags.map((tag) => (
-                              <span
-                                key={tag}
-                                className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#13278A]"
-                              >
-                                #{tag}
-                              </span>
-                            ))}
-                          </div>
-                          {item.emotions && item.emotions.length > 0 && (
-                            <>
-                              <span className="h-3.5 w-px bg-[#E5E5E5]" />
-                              <div className="flex items-center gap-1.5">
-                                {item.emotions.map((emotion) => (
-                                  <EmotionIcon key={emotion} name={emotion} size={24} />
-                                ))}
-                              </div>
-                            </>
-                          )}
-                        </div>
-                        <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
-                          {item.paymentMethod}
-                        </p>
-                      </div>
-
-                      {item.memo && (
-                        <p className="text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#9FA4A8]">
-                          {item.memo}
-                        </p>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
+                )}
+              </div>
             </div>
-          </div>
           </>
         )}
       </div>
+
+      <ConfirmModal
+        isOpen={deleteTarget !== null}
+        title={deleteTarget?.type === 'income' ? '수입을 삭제하시겠어요?' : '지출을 삭제하시겠어요?'}
+        message="이 작업은 되돌릴 수 없습니다."
+        confirmText="삭제"
+        cancelText="취소"
+        isDangerous
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/src/widgets/record/RecordContent.tsx
+++ b/src/widgets/record/RecordContent.tsx
@@ -15,6 +15,9 @@ import { useGetAssets } from '@/entities/get-assets/useGetAssets';
 import { usePostAsset } from '@/features/post-asset/model/usePostAsset';
 import { useUpdateAsset } from '@/features/post-asset/model/useUpdateAsset';
 import { usePostIncome } from '@/features/post-income/model/usePostIncome';
+import { useUpdateIncome } from '@/features/update-income/model/useUpdateIncome';
+import { useQuery } from '@tanstack/react-query';
+import { incomeQueries } from '@/entities/income';
 import {
   formatDateDisplay,
   calculateExpression,
@@ -41,12 +44,14 @@ export default function RecordContent() {
   const typeParam = searchParams?.get('type');
   const expenseIdParam = searchParams?.get('expenseId');
   const assetIdParam = searchParams?.get('assetId');
+  const incomeIdParam = searchParams?.get('incomeId');
   const modeParam = searchParams?.get('mode');
   const isEditMode = !!(modeParam === 'edit' && expenseIdParam);
   const isAssetEditMode = !!(typeParam === 'asset' && assetIdParam);
+  const isIncomeEditMode = !!(modeParam === 'edit' && incomeIdParam);
   const isAssetMode = typeParam === 'asset';
   const initialType: 'income' | 'expense' =
-    typeParam === 'income' || isAssetMode ? 'income' : 'expense';
+    typeParam === 'income' || isAssetMode || isIncomeEditMode ? 'income' : 'expense';
 
   // Edit 모드일 때 기존 데이터 로드
   const expenseYear = parseInt(selectedDate.split('-')[0]);
@@ -154,6 +159,37 @@ export default function RecordContent() {
   const { getUser } = useUser();
   const user = getUser();
 
+  // 수입 edit 모드용 데이터 로드
+  const { data: monthlyIncomes = [] } = useQuery({
+    ...incomeQueries.monthly(accessToken || '', expenseYear, expenseMonth),
+    enabled: isIncomeEditMode && !!accessToken,
+  });
+
+  const targetIncome = useMemo(() => {
+    if (!isIncomeEditMode || !incomeIdParam || monthlyIncomes.length === 0) return null;
+    return monthlyIncomes.find((i) => i.incomeId === parseInt(incomeIdParam));
+  }, [isIncomeEditMode, incomeIdParam, monthlyIncomes]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (targetIncome) {
+      setRecord({
+        amount: targetIncome.amount,
+        type: 'income',
+        date: targetIncome.incomeDate,
+        categoryId: targetIncome.incomeCategoryId,
+        paymentMethodId: null,
+        emotionIds: [],
+        situationTagIds: [],
+        memo: targetIncome.memo || '',
+      });
+      setAmountInput(targetIncome.amount.toString());
+      setSelectedCategoryId(targetIncome.incomeCategoryId);
+      setTempMemo(targetIncome.memo || '');
+    }
+  }, [targetIncome]);
+
+  const updateIncomeMutation = useUpdateIncome();
 
   const handleCategorySelect = (category: number) => {
     setSelectedCategoryId(category);
@@ -202,11 +238,12 @@ export default function RecordContent() {
     setIsMemoOpen(false);
   };
 
-  const handleDateSave = () => {
+  const handleDateSave = (date: string) => {
     setRecord((prev) => ({
       ...prev,
-      date: tempDate,
+      date,
     }));
+    setTempDate(date);
     setIsDateOpen(false);
     setIsDateSelected(true);
   };
@@ -281,6 +318,25 @@ export default function RecordContent() {
           assetDate: record.date,
           memo: record.memo ?? ""
         });
+      } else if (isIncomeEditMode && incomeIdParam) {
+        updateIncomeMutation.mutate(
+          {
+            incomeId: parseInt(incomeIdParam),
+            body: {
+              amount: record.amount ?? 0,
+              incomeCategoryId: record.categoryId ?? 0,
+              incomeDate: record.date,
+              memo: record.memo ?? '',
+            },
+            year: expenseYear,
+            month: expenseMonth,
+          },
+          {
+            onSuccess: () => {
+              window.history.back();
+            },
+          },
+        );
       } else if (record.type === 'income') {
         postIncomeMutation.mutate({
           userId: user?.id ?? 0,
@@ -333,7 +389,7 @@ export default function RecordContent() {
 
   return (
     <div className="min-h-dvh bg-white" onClick={handleOutsideClick}>
-      <PageHeader title={isEditMode ? '지출 수정' : isAssetEditMode ? '자산 수정' : isAssetMode ? '자산 추가' : '가계부'} />
+      <PageHeader title={isEditMode ? '지출 수정' : isIncomeEditMode ? '수입 수정' : isAssetEditMode ? '자산 수정' : isAssetMode ? '자산 추가' : '가계부'} />
 
       <div className="px-6 py-6 pb-40">
         {/* Amount Section */}


### PR DESCRIPTION
## 작업 내용                                                                                                                               
   
  페이지(`/export`)와 동일한 패턴.                                                                                                           
                                                                                
  ### 데이터 레이어                                                                                                                          
  - `entities/income/model/income-schema.ts` — `incomeId` 필드 추가
  - `features/delete-income/` — `useDeleteIncome` mutation 신설                                                                              
  - `features/update-income/` — `useUpdateIncome` mutation 신설                
  - `features/delete-expense/model/useDeleteExpense.ts` — `expenseQueries.monthly` invalidate 추가 (캘린더 자동 갱신)                        
                                                                                                                     
  ### 캘린더                                                                    
  - `CalendarContent.tsx` — `expenseItems`/`incomeItems` 매핑에 `id` 필드 포함                                                               
                                                                                                                                             
  ### 바텀시트 (`DateBottomSheet.tsx`)                                                                                                       
  - 좌측 스와이프(30px 이상) → 우측 휴지통 버튼 노출                                                                                         
  - 휴지통 클릭 → `ConfirmModal`로 한 번 더 확인 → mutation 실행                                                                             
  - 항목 클릭(스와이프 아님) → `/record?expenseId=X&date=Y&mode=edit` 또는 `/record?incomeId=X&date=Y&mode=edit`로 라우팅                    
  - 지출 탭에서 항목이 없을 때 "지출 기록이 아직 없어요" empty 메시지 표시                                                                   
                                                                                                                                             
  ### record 페이지 (수입 수정 모드 추가)                                                                                                    
  - `incomeId` 쿼리 파라미터 + `isIncomeEditMode` 분기                                                                                       
  - `monthlyIncomes`에서 `targetIncome` 찾아 폼에 자동 입력                                                                                  
  - 저장 시 `useUpdateIncome.mutate` → 성공 시 이전 페이지로 복귀                                                                            
  - PageHeader title "수입 수정" 케이스 추가                                                                                                 
                                                                                                                                             
  ### 부수 수정                                                                                                                              
  - 날짜 선택 BottomSheet의 `handleDateSave` 인자 처리 수정 — 클릭한 날짜가 `record.date`에 정확히 반영되지 않던 버그 해결