### PR TITLE
[FIX] 회고 결과 텍스트 줄바꿈 처리

### DIFF
--- a/src/widgets/retro/RetroResultContent.tsx
+++ b/src/widgets/retro/RetroResultContent.tsx
@@ -43,7 +43,7 @@ export default function RetroResultContent() {
         <div className="flex flex-col gap-10 px-4 pt-5 pb-25">
           {/* 섹션 1: 타이틀 + 결과 카드 */}
           <div className="flex flex-col gap-5">
-            <p className="text-[22px] font-bold leading-normal tracking-[-0.55px] text-[#1C1D1F]">
+            <p className="whitespace-pre-line text-[22px] font-bold leading-normal tracking-[-0.55px] text-[#1C1D1F]">
               {data.title.prefixText}
               <br />
               <span className="text-[#13278A]">{data.title.highlightText}</span>
@@ -62,7 +62,7 @@ export default function RetroResultContent() {
                 <p className="w-18.75 whitespace-nowrap text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#474C52]">
                   소비 이유:
                 </p>
-                <p className="text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#030303]">
+                <p className="whitespace-pre-line text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#030303]">
                   {data.options.situationTagName}
                 </p>
               </div>
@@ -87,7 +87,7 @@ export default function RetroResultContent() {
                 <p className="w-18.75 whitespace-nowrap text-[16px] font-medium leading-normal tracking-[-0.4px] text-[#474C52]">
                   내일의 다짐:
                 </p>
-                <p className="text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#030303]">
+                <p className="whitespace-pre-line text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#030303]">
                   {data.options.nextActionOptionText}
                 </p>
               </div>
@@ -131,7 +131,7 @@ export default function RetroResultContent() {
                       />
                     </svg>
                   </span>
-                  <p className="text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#27282C]">
+                  <p className="whitespace-pre-line text-[14px] font-medium leading-normal tracking-[-0.35px] text-[#27282C]">
                     {item}
                   </p>
                 </div>


### PR DESCRIPTION
## 배경                                                                       
  백엔드에서 회고 결과 텍스트의 마침표를 제거하고 대신 개행문자(\n)로 보내도록 변경됨. 프론트에서 \n을 줄바꿈으로 렌더링하도록 처리.         
                                                                                                                                    
  ## 작업 내용                                                                                                                               
  `widgets/retro/RetroResultContent.tsx`의 백엔드 응답 텍스트 출력부에 `whitespace-pre-line` 클래스 추가:                                  
  - `data.title.prefixText` / `suffixText`                                                                                                   
  - `data.options.situationTagName`                                            
  - `data.options.nextActionOptionText`                                                                                                      
  - `data.result.guideItems` 의 각 item                                         
                                                                                                                                             
  `data.result.feedbackText`는 이전부터 적용되어 있어 변경 없음.                                                                             
                                                                                                                                             
  ## 검증                                                                                                                                    
  - [ ] 백엔드 응답에 \n이 포함된 텍스트가 줄바꿈으로 표시됨                                                                                 
  - [ ] \n이 없는 텍스트는 한 줄로 정상 표시                                                                                                 
  - [ ] 마지막 줄 끝의 \n은 빈 줄을 만들지 않음 (`white-space: pre-line` 동작 확인됨)