### PR TITLE
[FIX] 다크모드 환경에서 강제 색상 반전 방지

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -90,6 +90,7 @@ html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow-y: scroll;
+  color-scheme: light only;
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,6 +39,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
+  colorScheme: "light",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary                                                                                                                                 
  - 다크모드 환경 또는 브라우저의 강제 다크모드(force-dark)에서 사이트 색상이 의도와 다르게 반전/조정되던 문제 해결                          
  - `color-scheme: light only` 적용으로 모든 브라우저에서 항상 디자인된 라이트 색상으로 표시                                                 
                                                                                                                                             
  ## 변경 내용                                                                                                                               
  - `src/app/globals.css`: `html`에 `color-scheme: light only` 추가                                                                          
  - `src/app/layout.tsx`: `viewport.colorScheme: 'light'` 추가