### PR TITLE
[FIX] 자산 메인 페이지 수정

### DIFF
--- a/src/entities/get-assets/useGetAssets.ts
+++ b/src/entities/get-assets/useGetAssets.ts
@@ -73,13 +73,48 @@ export function useGetAssets(params: GetAssetsParams, enabled = true) {
 
       const totalAmount = allAssets.reduce((sum, asset) => sum + asset.amount, 0);
 
+      // 카테고리별 최신/오래된 자산 (날짜 + assetId 보조 정렬)
+      // 같은 날짜라면 assetId가 큰 게 더 나중에 등록된 것으로 처리
+      const categoryDates: Record<number, { latest: number; oldest: number; latestId: number; oldestId: number }> = {};
+      allAssets.forEach((asset) => {
+        const time = new Date(asset.assetDate).getTime();
+        const cur = categoryDates[asset.assetCategoryId];
+        if (!cur) {
+          categoryDates[asset.assetCategoryId] = { latest: time, oldest: time, latestId: asset.assetId, oldestId: asset.assetId };
+        } else {
+          if (time > cur.latest || (time === cur.latest && asset.assetId > cur.latestId)) {
+            cur.latest = time;
+            cur.latestId = asset.assetId;
+          }
+          if (time < cur.oldest || (time === cur.oldest && asset.assetId < cur.oldestId)) {
+            cur.oldest = time;
+            cur.oldestId = asset.assetId;
+          }
+        }
+      });
+
       // 카테고리별 정보 구성
       const categories = ASSET_CATEGORIES
         .map((cat, idx) => ({
           ...cat,
           total: categoryTotals[idx + 1] || 0,
+          latest: categoryDates[idx + 1]?.latest ?? 0,
+          oldest: categoryDates[idx + 1]?.oldest ?? 0,
+          latestId: categoryDates[idx + 1]?.latestId ?? 0,
+          oldestId: categoryDates[idx + 1]?.oldestId ?? 0,
         }))
-        .filter(cat => cat.total > 0);
+        .filter(cat => cat.total > 0)
+        .sort((a, b) => {
+          if (params.sort === 'AMOUNT_DESC') return b.total - a.total;
+          if (params.sort === 'AMOUNT_ASC') return a.total - b.total;
+          if (params.sort === 'OLDEST') {
+            if (a.oldest !== b.oldest) return a.oldest - b.oldest;
+            return a.oldestId - b.oldestId;
+          }
+          // LATEST
+          if (a.latest !== b.latest) return b.latest - a.latest;
+          return b.latestId - a.latestId;
+        });
 
       return {
         data: paginatedAssets,

--- a/src/entities/get-assets/useGetAssets.ts
+++ b/src/entities/get-assets/useGetAssets.ts
@@ -73,48 +73,11 @@ export function useGetAssets(params: GetAssetsParams, enabled = true) {
 
       const totalAmount = allAssets.reduce((sum, asset) => sum + asset.amount, 0);
 
-      // 카테고리별 최신/오래된 자산 (날짜 + assetId 보조 정렬)
-      // 같은 날짜라면 assetId가 큰 게 더 나중에 등록된 것으로 처리
-      const categoryDates: Record<number, { latest: number; oldest: number; latestId: number; oldestId: number }> = {};
-      allAssets.forEach((asset) => {
-        const time = new Date(asset.assetDate).getTime();
-        const cur = categoryDates[asset.assetCategoryId];
-        if (!cur) {
-          categoryDates[asset.assetCategoryId] = { latest: time, oldest: time, latestId: asset.assetId, oldestId: asset.assetId };
-        } else {
-          if (time > cur.latest || (time === cur.latest && asset.assetId > cur.latestId)) {
-            cur.latest = time;
-            cur.latestId = asset.assetId;
-          }
-          if (time < cur.oldest || (time === cur.oldest && asset.assetId < cur.oldestId)) {
-            cur.oldest = time;
-            cur.oldestId = asset.assetId;
-          }
-        }
-      });
-
-      // 카테고리별 정보 구성
-      const categories = ASSET_CATEGORIES
-        .map((cat, idx) => ({
-          ...cat,
-          total: categoryTotals[idx + 1] || 0,
-          latest: categoryDates[idx + 1]?.latest ?? 0,
-          oldest: categoryDates[idx + 1]?.oldest ?? 0,
-          latestId: categoryDates[idx + 1]?.latestId ?? 0,
-          oldestId: categoryDates[idx + 1]?.oldestId ?? 0,
-        }))
-        .filter(cat => cat.total > 0)
-        .sort((a, b) => {
-          if (params.sort === 'AMOUNT_DESC') return b.total - a.total;
-          if (params.sort === 'AMOUNT_ASC') return a.total - b.total;
-          if (params.sort === 'OLDEST') {
-            if (a.oldest !== b.oldest) return a.oldest - b.oldest;
-            return a.oldestId - b.oldestId;
-          }
-          // LATEST
-          if (a.latest !== b.latest) return b.latest - a.latest;
-          return b.latestId - a.latestId;
-        });
+      // 카테고리별 정보 구성 (메인 페이지: 0원 포함, 정의 순서 유지)
+      const categories = ASSET_CATEGORIES.map((cat, idx) => ({
+        ...cat,
+        total: categoryTotals[idx + 1] || 0,
+      }));
 
       return {
         data: paginatedAssets,

--- a/src/widgets/asset/AssetContent.tsx
+++ b/src/widgets/asset/AssetContent.tsx
@@ -4,27 +4,17 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Footer from '@/shared/ui/Footer';
 import PageHeader from '@/shared/ui/PageHeader';
-import SortButton, { SortType } from '@/shared/ui/SortButton';
 import ConfirmModal from '@/shared/ui/ConfirmModal';
 import { useGetAssets } from '@/entities/get-assets/useGetAssets';
 import { useUser } from '@/shared/store';
-
-const SORT_MAPPING: Record<SortType, 'LATEST' | 'OLDEST' | 'AMOUNT_ASC' | 'AMOUNT_DESC'> = {
-  latest: 'LATEST',
-  expensive: 'AMOUNT_DESC',
-  cheap: 'AMOUNT_ASC',
-  oldest: 'OLDEST',
-};
 
 export default function AssetContent() {
   const router = useRouter();
   const { getUser } = useUser();
   const user = getUser();
-  const [sortType, setSortType] = useState<SortType>('latest');
   const [showLoginModal, setShowLoginModal] = useState(false);
 
   const { data: assetsData, isLoading } = useGetAssets({
-    sort: SORT_MAPPING[sortType],
     page: 0,
     size: 100,
   });
@@ -117,9 +107,7 @@ export default function AssetContent() {
           </p>
         </div>
       ) : (
-        <div className="flex flex-col gap-3.75 px-4 pt-12.5">
-          <SortButton sortType={sortType} onSortChange={setSortType} />
-
+        <div className="flex flex-col gap-3.75 px-4 pt-7.5">
           {groupedAssets.map((category) => (
             <button
               key={category.id}
@@ -135,11 +123,13 @@ export default function AssetContent() {
                   {category.label}
                 </span>
               </div>
-              <div className="flex items-center gap-1.25">
+              <div className="flex items-center gap-2">
                 <p className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#1C1D1F]">
                   {category.total.toLocaleString()}원
                 </p>
-                <img src="/svg/icon_arrow_right.svg" alt="" width={26} height={26} />
+                <svg width="26" height="26" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                  <path d="M8.7998 18.4L15.1998 12L8.7998 5.59998" stroke="#9FA4A8" strokeWidth="1.73333" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
               </div>
             </button>
           ))}

--- a/src/widgets/asset/AssetDetailContent.tsx
+++ b/src/widgets/asset/AssetDetailContent.tsx
@@ -166,7 +166,7 @@ export default function AssetDetailContent({ categoryId }: AssetDetailContentPro
             </p>
           </div>
         ) : (
-          <div className="flex flex-col gap-5 mt-4">
+          <div className="flex flex-col gap-5 mt-3.75">
             {records.map((record, idx) => (
               <div
                 key={idx}


### PR DESCRIPTION
## Summary                                                                                                                                 
  - 자산 메인 페이지를 피그마 스펙에 맞춰 정리                                                                                               
  - 0원 카테고리도 모두 노출되도록 수정                                                                                                      
  - 정렬 드롭다운 제거                                                   
  - 총 자산 → 카테고리 리스트 여백 및 화살표 색상/간격 피그마 매칭                                                                           
                                                                                                                                             
  ## 변경 내용                                                                                                                               
                                                                                                                                             
  ### `AssetContent.tsx`                                                                                                                     
  - `SortButton` import 및 관련 state(`sortType`), `SORT_MAPPING` 상수 제거                                                                  
  - 총 자산 → 카테고리 리스트 여백 `pt-12.5` (50px) → `pt-7.5` (30px)                                                                        
  - 화살표 SVG 인라인 처리 + 색상 `#9FA4A8` (Gray 4) 적용                       
  - 금액 ↔ 화살표 간격 `gap-1.25` (5px) → `gap-2` (8px)                                                                                      
                                                                                
  ### `useGetAssets.ts`                                                                                                                      
  - 카테고리 정렬 로직 제거 (`categoryDates`, sort 분기)                                                                                     
  - `.filter(cat => cat.total > 0)` 제거 → 0원 카테고리도 노출                                                                               
  - `ASSET_CATEGORIES` 정의 순서대로 표시 (급여 → 용돈 → 부수입 → 상여금 → 금융수입 → 기타)                                                  
                                                                                                                                             
  ## Test plan                                                                                                                               
  - [x] 자산 메인 페이지에 6개 카테고리가 모두 노출되는지 확인 (0원 포함)                                                                    
  - [x] 정렬 드롭다운이 사라졌는지 확인                                                                                                      
  - [x] 피그마 디자인과 일치하는지 확인                                                                 
                                                                                                                                             
  Closes #136