### PR TITLE
[FIX] 오늘의 지출 비용 같은 카테고리 합산 표시 분리

### DIFF
--- a/src/shared/ui/house-hold/TodayExpenseBox.tsx
+++ b/src/shared/ui/house-hold/TodayExpenseBox.tsx
@@ -70,41 +70,35 @@ export default function TodayExpenseBox({ emotions, expenseCategories }: TodayEx
     return monthData.filter((item) => item.expenseDate === dateString);
   }, [monthData, dateString]);
 
-  // 카테고리별로 그룹핑
+  // 개별 지출 항목으로 매핑 (같은 카테고리도 합산하지 않고 각각 표시)
   const expenseData = useMemo(() => {
-    const categoryMap = new Map<number, { name: string; amount: number; emotions: any[] }>();
+    const items = dailyExpenseList.map((expense) => {
+      const categoryLabel = expenseCategories && Array.isArray(expenseCategories)
+        ? expenseCategories.flatMap((g) => g.items).find((item) => item.id === expense.categoryId)?.label || '기타'
+        : '기타';
 
-    dailyExpenseList.forEach((expense) => {
-      if (!categoryMap.has(expense.categoryId)) {
-        const categoryLabel = expenseCategories && Array.isArray(expenseCategories)
-          ? expenseCategories.flatMap((g) => g.items).find((item) => item.id === expense.categoryId)?.label || '기타'
-          : '기타';
-
-        categoryMap.set(expense.categoryId, {
-          name: categoryLabel,
-          amount: 0,
-          emotions: [],
-        });
-      }
-      const category = categoryMap.get(expense.categoryId)!;
-      category.amount += expense.amount;
-
-      // emotionIds를 사용해서 emotion 정보 추가
+      const expenseEmotions: any[] = [];
       if (expense.emotionIds && expense.emotionIds.length > 0) {
         expense.emotionIds.forEach((emotionId) => {
           const emotion = emotions && Array.isArray(emotions)
             ? emotions.flatMap((g) => g.items).find((item) => item.id === emotionId)
             : undefined;
-          if (emotion && !category.emotions.find((e) => e.id === emotion.id)) {
-            category.emotions.push(emotion);
+          if (emotion && !expenseEmotions.find((e) => e.id === emotion.id)) {
+            expenseEmotions.push(emotion);
           }
         });
       }
+
+      return {
+        name: categoryLabel,
+        amount: expense.amount,
+        emotions: expenseEmotions,
+      };
     });
 
     return {
       totalAmount: dailyExpenseList.reduce((sum, item) => sum + item.amount, 0),
-      categories: Array.from(categoryMap.values()),
+      categories: items,
     };
   }, [dailyExpenseList, emotions, expenseCategories]);
 


### PR DESCRIPTION
## Summary                                                                                                                                 
  - 홈 화면 "오늘의 지출 비용"에서 같은 카테고리의 지출이 합산되어 한 줄로 표시되던 문제 해결                                                
  - 각 지출을 개별 항목으로 분리해서 표시하도록 수정                                                                                         
                                                                                                                                             
  ## Before / After                                                                                                                          
  **Before**: 카페 5,000원 + 카페 3,000원 → "카페 8,000원" 한 줄                                                                             
  **After**: 카페 5,000원 / 카페 3,000원 두 줄로 각각 표시                                                                                   
                                                                                                                                             
  ## 변경 내용                                                                                                                               
  ### `src/shared/ui/house-hold/TodayExpenseBox.tsx`                                                                                         
  - `categoryMap` 기반 카테고리별 합산 로직 제거                                                                                             
  - `dailyExpenseList`를 그대로 매핑하여 각 expense를 독립 항목으로 변환                                                                     
  - 각 항목의 emotion도 해당 expense의 `emotionIds`로만 매핑 (다른 지출의 감정과 섞이지 않음)                                                
  - 메인 화면 상위 3개 노출 + 더보기 동작은 기존 그대로 유지                                                                                 
                                                                                                                                             
  ## Test plan                                                                  
  - [ ] 같은 카테고리로 두 건 이상의 지출 등록 후 홈 화면에서 각각 표시되는지 확인                                                           
  - [ ] 각 지출 항목의 감정 태그가 해당 지출의 감정만 표시되는지 확인                                                                        
  - [ ] 4건 이상 등록 시 상위 3건만 노출 + "더보기" 동작 정상 확인                                                                           
  - [ ] 총 지출 금액(합산)은 기존대로 정확히 계산되는지 확인

Closes #138