### PR TITLE
[FIX] 모달 오버레이 진입/종료 애니메이션 튐 현상 수정

### DIFF
--- a/src/shared/ui/ConfirmModal.tsx
+++ b/src/shared/ui/ConfirmModal.tsx
@@ -25,16 +25,21 @@ export default function ConfirmModal({
   onCancel,
   isDangerous = false,
 }: ConfirmModalProps) {
-  if (!isOpen) return null;
+  const visibilityClass = isOpen
+    ? 'opacity-100 pointer-events-auto'
+    : 'opacity-0 pointer-events-none';
 
   return (
     <>
-      <div className="animate-fade-in fixed inset-0 right-0 left-0 z-50 mx-auto max-w-md bg-black opacity-50" />
+      <div
+        className={`fixed inset-0 right-0 left-0 z-50 mx-auto max-w-md bg-black transition-opacity duration-200 ${
+          isOpen ? 'opacity-50 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        }`}
+        aria-hidden="true"
+      />
       {type === 'loginCheck' || type === 'logoutCheck' || type === 'deleteCheck' ? (
         <div
-          className={
-            'box__container__2 fixed top-1/2 right-0 left-0 z-60 mx-auto h-auto w-70.75 -translate-y-1/2 rounded-[10px] bg-white px-5.25 pt-12.25 pb-5'
-          }
+          className={`box__container__2 fixed top-1/2 right-0 left-0 z-60 mx-auto h-auto w-70.75 -translate-y-1/2 rounded-[10px] bg-white px-5.25 pt-12.25 pb-5 transition-opacity duration-200 ${visibilityClass}`}
         >
           <span className={'mb-1 block text-center text-[14px] font-bold'}>{title}</span>
           <span className={'text-ray-600 mb-8 block text-center text-[14px]'}>{secondary}</span>
@@ -50,7 +55,9 @@ export default function ConfirmModal({
           </div>
         </div>
       ) : (
-        <div className="box__container fixed top-1/2 right-0 left-0 z-60 mx-auto h-auto w-70 -translate-y-1/2 rounded-[10px] bg-white px-6 pt-8 pb-5">
+        <div
+          className={`box__container fixed top-1/2 right-0 left-0 z-60 mx-auto h-auto w-70 -translate-y-1/2 rounded-[10px] bg-white px-6 pt-8 pb-5 transition-opacity duration-200 ${visibilityClass}`}
+        >
           <span className="block text-center text-[16px] font-bold text-[#030303]">
             {title.includes('|')
               ? title.split('|').map((item) => (


### PR DESCRIPTION
## Summary                                                                                                                                 
  - 모든 팝업(`ConfirmModal`)에서 오버레이/모달 본체가 부드럽게 페이드 인/아웃 되도록 수정                                                   
  - 모달 진입/종료 시 발생하던 깜빡임 현상 해결                                                                                              
                                                                                                                                             
  ## 원인                                                                                                                                    
  `src/shared/ui/ConfirmModal.tsx`:                                                                                                          
  1. `if (!isOpen) return null` — 닫힐 때 즉시 unmount 되어 종료 애니메이션 없음                                                             
  2. 진입에만 `animate-fade-in` 적용 / 종료 애니메이션 미정의                                                                                
  3. 로그아웃 등에서 모달 close + `router.push`가 동시에 발생하며 한 프레임 깜빡임                                                           
                                                                                                                                             
  ## 변경 내용                                                                                                                               
  ### `src/shared/ui/ConfirmModal.tsx`                                                                                                       
  - `if (!isOpen) return null` 제거 → 항상 마운트                                                                                            
  - `animate-fade-in` 제거 → `transition-opacity duration-200`로 통일                                                                        
  - 오버레이: `opacity-50 ↔ opacity-0` 부드러운 전환                                                                                         
  - 모달 본체: `opacity-100 ↔ opacity-0` 부드러운 전환                                                                                       
  - 닫힌 상태에서 `pointer-events-none`으로 클릭/터치 차단                                                                                   
  - 오버레이에 `aria-hidden` 추가 (스크린리더 무시)                                                                                          
                                                                                                                                             
  ## 영향 범위                                                                                                                               
  `ConfirmModal`을 사용하는 모든 페이지:                                                                                                     
  - 로그인 확인 (메인, 자산, 회고 등)                                                                                                        
  - 로그아웃 확인                                                                                                                            
  - 자산 삭제 확인                                                                                                                           
  - 가계부 삭제 확인                                                                                                                         
  - 기타 모든 확인 모달

Closes #140 