### PR TITLE
[FIX] PC 환경에서 모바일 비율로 변경

### DIFF
--- a/src/app/BackgroundProvider.tsx
+++ b/src/app/BackgroundProvider.tsx
@@ -24,14 +24,18 @@ export default function BackgroundProvider({ children }: { children: React.React
       document.head.appendChild(meta);
     }
     meta.content = color;
-    document.body.style.backgroundColor = color;
+
+    // 모바일에서는 status bar/swipe 영역 색을 페이지 색과 맞춤
+    // PC에서는 외부 wrapper(gray-100)와 일치시켜 화면 가장자리 색 튐 방지
+    const isDesktop = window.matchMedia('(min-width: 768px)').matches;
+    document.body.style.backgroundColor = isDesktop ? '#f3f4f6' : color;
   }, [pathname]);
 
   return (
-    <div className="min-h-dvh w-full bg-gray-100">
+    <div className="min-h-dvh w-full bg-gray-100 md:flex md:items-center md:justify-center">
       <div
         className={cn(
-          'mx-auto flex min-h-dvh w-full max-w-md flex-col',
+          'mx-auto flex min-h-dvh w-full max-w-md flex-col md:min-h-0 md:h-dvh md:w-[390px] md:max-w-[390px] md:max-h-[792px]',
           isHomePage
             ? 'bg-[linear-gradient(180deg,#cce1ff_8.65%,#f3f8ff_100%)]' :
             isLoginPage ? 'bg-[#13278a]' : 'bg-white'

--- a/src/widgets/login/LoginContent.tsx
+++ b/src/widgets/login/LoginContent.tsx
@@ -17,7 +17,7 @@ export default function LoginContent() {
   return (
     <>
       <ConfirmModal isOpen={errorBox} noCancel title={"로그인 중 문제가 발생했어요.|다시 시도해주세요."} onConfirm={() => setErrorBox(false)} onCancel={() => setErrorBox(false)} />
-      <div className={'login__content__wrapper flex flex-col min-h-dvh'}>
+      <div className={'login__content__wrapper flex flex-1 flex-col'}>
         <div className={'logo__part flex flex-col items-center pt-[146px]'}>
           <Image
             src={'/svg/feel_log_big.svg'}


### PR DESCRIPTION
## Summary                                                                          
  - PC(데스크톱) 환경에서 페이지가 viewport 풀 높이로 늘어나며 콘텐츠가 위/아래로 비정상 배치되던 문제 해결                                                           
  - PC에서는 모바일 비율(390×792, 피그마 기준 statusbar 제외 영역)로 가운데 정렬 표시 
  - 모바일 환경은 기존 동작 그대로 유지                                               
                                                                                      
  ## 원인                                                                             
  - `BackgroundProvider.tsx`의 컨테이너가 `min-h-dvh`로 viewport 풀 높이를 강제 → 큰 모니터에서 컨테이너가 과도하게 길어짐                                               
  - `LoginContent.tsx`의 `min-h-dvh`가 부모 컨테이너 max-height를 뚫고 자식 컨텐츠가 잘리는 부수 문제                                                                    
                                                                                      
  ## 변경 내용                                                                        
                                                                                
  ### `src/app/BackgroundProvider.tsx`                                                
  - 외부 wrapper: `md:flex md:items-center md:justify-center` 추가 → PC에서 가운데 정렬                                                                                
  - 내부 컨테이너: `md:min-h-0 md:h-dvh md:w-[390px] md:max-w-[390px] md:max-h-[792px]` 추가                                                              
    - PC에서 모바일 디바이스 비율(390×792, 피그마 statusbar 제외)로 고정                                                                         
                                                                                      
  ### `src/widgets/login/LoginContent.tsx`                                     
  - `min-h-dvh` → `flex flex-1 flex-col`                                              
  - 부모 컨테이너 높이에 맞춰 자식이 fit