### PR TITLE
[FIX] PC 환경 모바일 비율 제한 제거

### DIFF
--- a/src/app/BackgroundProvider.tsx
+++ b/src/app/BackgroundProvider.tsx
@@ -24,18 +24,14 @@ export default function BackgroundProvider({ children }: { children: React.React
       document.head.appendChild(meta);
     }
     meta.content = color;
-
-    // 모바일에서는 status bar/swipe 영역 색을 페이지 색과 맞춤
-    // PC에서는 외부 wrapper(gray-100)와 일치시켜 화면 가장자리 색 튐 방지
-    const isDesktop = window.matchMedia('(min-width: 768px)').matches;
-    document.body.style.backgroundColor = isDesktop ? '#f3f4f6' : color;
+    document.body.style.backgroundColor = color;
   }, [pathname]);
 
   return (
-    <div className="min-h-dvh w-full bg-gray-100 md:flex md:items-center md:justify-center">
+    <div className="min-h-dvh w-full bg-gray-100">
       <div
         className={cn(
-          'mx-auto flex min-h-dvh w-full max-w-md flex-col md:min-h-0 md:h-dvh md:w-[390px] md:max-w-[390px] md:max-h-[792px]',
+          'mx-auto flex min-h-dvh w-full max-w-md flex-col',
           isHomePage
             ? 'bg-[linear-gradient(180deg,#cce1ff_8.65%,#f3f8ff_100%)]' :
             isLoginPage ? 'bg-[#13278a]' : 'bg-white'

--- a/src/widgets/login/LoginContent.tsx
+++ b/src/widgets/login/LoginContent.tsx
@@ -17,7 +17,7 @@ export default function LoginContent() {
   return (
     <>
       <ConfirmModal isOpen={errorBox} noCancel title={"로그인 중 문제가 발생했어요.|다시 시도해주세요."} onConfirm={() => setErrorBox(false)} onCancel={() => setErrorBox(false)} />
-      <div className={'login__content__wrapper flex flex-1 flex-col'}>
+      <div className={'login__content__wrapper flex flex-col min-h-dvh'}>
         <div className={'logo__part flex flex-col items-center pt-[146px]'}>
           <Image
             src={'/svg/feel_log_big.svg'}


### PR DESCRIPTION
  ## 문제                                                                                                                                    
  이전 PR(#143)로 적용된 PC 환경 모바일 비율 제한(컨테이너 가운데 정렬, max-h-[792px], LoginContent flex-1 등)이 다음 사이드 이펙트를        
  발생시킴:                                                                                                                                  
  1. 푸터가 컨테이너 밖으로 튀어나옴 (viewport center vs 컨테이너 center 차이)  
  2. 로그인 페이지 콘텐츠 잘림                                                                                                               
  3. 페이지별 콘텐츠 높이 불일치                                                
                                                                                                                                             
  ## 결정                                                                      
  - PC 모바일 비율 제한을 완전히 제거하고 모바일 우선 디자인(`min-h-dvh`)으로 통일                                                            
  - PC에서는 컨테이너가 viewport 풀 높이로 늘어나며 콘텐츠가 위에서부터 자연 흐름