### PR TITLE
[FIX] 데이터 변경 후 새로고침 필요, 새로고침 시 로그인 팝업 문제 해결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,12 @@ const withBundleAnalyzer = bundleAnalyzer({
 });
 
 const nextConfig: NextConfig = {
+  experimental: {
+    staleTimes: {
+      dynamic: 0,
+      static: 0,
+    },
+  },
   async headers() {
     return [
       {

--- a/src/features/delete-expense/model/useDeleteExpense.ts
+++ b/src/features/delete-expense/model/useDeleteExpense.ts
@@ -1,25 +1,13 @@
 import { deleteExpenseApi } from '@/features/delete-expense/api/delete-expense-api';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { expenseQueries } from '@/entities/expense';
-import { todayExpendQueries } from '@/entities/today-expenditure/api/today-expend-queries';
 
-export function useDeleteExpense(year: number, month: number, day: number) {
+export function useDeleteExpense(_year: number, _month: number, _day: number) {
   const queryClient = useQueryClient();
 
   const mutation = useMutation<void, unknown, number>({
     mutationFn: (expenseId: number) => deleteExpenseApi(expenseId),
     onSuccess: async () => {
-      await Promise.all([
-        queryClient.refetchQueries({
-          queryKey: ['daily-expend', year, month, day],
-        }),
-        queryClient.refetchQueries({
-          queryKey: expenseQueries.monthly('', year, month).queryKey,
-        }),
-        queryClient.refetchQueries({
-          queryKey: todayExpendQueries.getTodayQueries(year, month).queryKey,
-        }),
-      ]);
+      await queryClient.invalidateQueries({ refetchType: 'all' });
     },
     onError: (error: unknown) => {
       console.error('삭제 실패:', error);

--- a/src/features/delete-income/model/useDeleteIncome.ts
+++ b/src/features/delete-income/model/useDeleteIncome.ts
@@ -1,16 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteIncomeApi } from '@/features/delete-income/api/delete-income-api';
-import { incomeQueries } from '@/entities/income';
 
-export function useDeleteIncome(year: number, month: number) {
+export function useDeleteIncome(_year: number, _month: number) {
   const queryClient = useQueryClient();
 
   return useMutation<void, unknown, number>({
     mutationFn: (incomeId: number) => deleteIncomeApi(incomeId),
     onSuccess: async () => {
-      await queryClient.refetchQueries({
-        queryKey: incomeQueries.monthly('', year, month).queryKey,
-      });
+      await queryClient.invalidateQueries({ refetchType: 'all' });
     },
     onError: (error: unknown) => {
       console.error('수입 삭제 실패:', error);

--- a/src/features/post-asset/model/usePostAsset.ts
+++ b/src/features/post-asset/model/usePostAsset.ts
@@ -9,8 +9,9 @@ export function usePostAsset() {
   return useMutation<unknown, unknown, AssetRequestBody>({
     mutationFn: (req) => postAssetApi(req),
     onSuccess: async () => {
-      await queryClient.refetchQueries({ queryKey: ['assets'] });
+      await queryClient.invalidateQueries({ refetchType: 'all' });
       router.push('/asset');
+      router.refresh();
     }
   });
 }

--- a/src/features/post-asset/model/useUpdateAsset.ts
+++ b/src/features/post-asset/model/useUpdateAsset.ts
@@ -9,8 +9,9 @@ export function useUpdateAsset() {
   return useMutation<unknown, unknown, { assetId: number; request: AssetRequestBody }>({
     mutationFn: ({ assetId, request }) => patchAssetApi(assetId, request),
     onSuccess: async () => {
-      await queryClient.refetchQueries({ queryKey: ['assets'] });
+      await queryClient.invalidateQueries({ refetchType: 'all' });
       router.push('/asset');
+      router.refresh();
     }
   });
 }

--- a/src/features/post-house-hold/model/useHouseHoldPost.ts
+++ b/src/features/post-house-hold/model/useHouseHoldPost.ts
@@ -12,31 +12,9 @@ export function useHouseHoldPost(
   const mutation = useMutation<void>({
     mutationFn: async () => postHouseHoldApi(houseHoldPostRequest),
     onSuccess: async () => {
-      // 월별 지출 데이터 쿼리 무효화하여 새로운 데이터 fetch
-      const year = parseInt(houseHoldPostRequest.expenseDate.split('-')[0]);
-      const month = parseInt(houseHoldPostRequest.expenseDate.split('-')[1]);
-
-      // 데이터 무효화 및 refetch
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: ['today-expend', year, month]
-        }),
-        queryClient.invalidateQueries({
-          queryKey: ['week_expend_queries']
-        })
-      ]);
-
-      // refetch 수행
-      await Promise.all([
-        queryClient.refetchQueries({
-          queryKey: ['today-expend', year, month]
-        }),
-        queryClient.refetchQueries({
-          queryKey: ['week_expend_queries']
-        })
-      ]);
-
+      await queryClient.invalidateQueries({ refetchType: 'all' });
       router.push('/');
+      router.refresh();
     },
     onError: (error: unknown) => {
       console.error('추가 실패');

--- a/src/features/post-income/model/usePostIncome.ts
+++ b/src/features/post-income/model/usePostIncome.ts
@@ -8,20 +8,10 @@ export function usePostIncome() {
 
   const mutation = useMutation<void, unknown, PostIncomeRequest>({
     mutationFn: async (request) => postIncomeApi(request),
-    onSuccess: async (_, request) => {
-      const year = request.incomeDate.split('-')[0];
-      const month = request.incomeDate.split('-')[1];
-
-      await Promise.all([
-        queryClient.refetchQueries({
-          queryKey: ['today-expend', Number(year), Number(month)],
-        }),
-        queryClient.refetchQueries({
-          queryKey: ['week_expend_queries'],
-        }),
-      ]);
-
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ refetchType: 'all' });
       router.push('/');
+      router.refresh();
     },
     onError: (error: unknown) => {
       console.error('수입 추가 실패');

--- a/src/features/update-expense/model/useUpdateExpense.ts
+++ b/src/features/update-expense/model/useUpdateExpense.ts
@@ -3,7 +3,6 @@ import {
   updateExpenseApi,
 } from '@/features/update-expense/api/update-expense-api';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 
 interface UseUpdateExpenseParams {
   expenseId: number;
@@ -11,14 +10,13 @@ interface UseUpdateExpenseParams {
 }
 
 export function useUpdateExpense() {
-  const router = useRouter();
   const queryClient = useQueryClient();
 
   const mutation = useMutation<void, unknown, UseUpdateExpenseParams>({
     mutationFn: async ({ expenseId, request }) => updateExpenseApi(expenseId, request),
     onSuccess: async () => {
-      await queryClient.refetchQueries({ queryKey: ['today-expend'] });
-      router.push('/');
+      await queryClient.invalidateQueries({ refetchType: 'all' });
+      window.location.href = '/';
     },
     onError: (error: unknown) => {
       console.error('수정 실패:', error);

--- a/src/features/update-income/model/useUpdateIncome.ts
+++ b/src/features/update-income/model/useUpdateIncome.ts
@@ -3,7 +3,6 @@ import {
   updateIncomeApi,
   type UpdateIncomeRequest,
 } from '@/features/update-income/api/update-income-api';
-import { incomeQueries } from '@/entities/income';
 
 interface UpdateIncomeArgs {
   incomeId: number;
@@ -17,10 +16,8 @@ export function useUpdateIncome() {
 
   return useMutation<void, unknown, UpdateIncomeArgs>({
     mutationFn: ({ incomeId, body }) => updateIncomeApi(incomeId, body),
-    onSuccess: async (_data, { year, month }) => {
-      await queryClient.invalidateQueries({
-        queryKey: incomeQueries.monthly('', year, month).queryKey,
-      });
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ refetchType: 'all' });
     },
     onError: (error: unknown) => {
       console.error('수입 수정 실패:', error);

--- a/src/shared/api/queryClient.ts
+++ b/src/shared/api/queryClient.ts
@@ -6,15 +6,14 @@ const isClientSide = typeof window !== 'undefined';
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 60,
+      staleTime: 0,
       gcTime: 1000 * 60 * 5,
       retry: (failureCount, error: any) => {
-        // 401은 이미 apiClient에서 처리되므로 retry하지 않음
-        // 다른 에러는 최대 2번까지 재시도
         if (error?.status === 401) return false;
         return failureCount < 2;
       },
       refetchOnWindowFocus: false,
+      refetchOnMount: 'always',
     },
     mutations: {
       retry: 0,

--- a/src/shared/store/token-store.ts
+++ b/src/shared/store/token-store.ts
@@ -64,10 +64,8 @@ export const useToken = create<tokenState>()(
         accessToken: state.accessToken,
         refreshToken: state.refreshToken,
       }),
-      onRehydrateStorage: () => (state) => {
-        if (state) {
-          state.isLoaded = true;
-        }
+      onRehydrateStorage: () => () => {
+        setTimeout(() => useToken.setState({ isLoaded: true }), 0);
       },
     }
   )

--- a/src/shared/store/user-store.ts
+++ b/src/shared/store/user-store.ts
@@ -41,16 +41,15 @@ export const useUser = create<UserState>()(
 
       getUser: () => {
         const state = get();
-        return state.isLoaded
-          ? {
-              id: state.id,
-              email: state.email,
-              nickname: state.nickname,
-              birthDate: state.birthDate,
-              gender: state.gender,
-              provider: state.provider,
-            }
-          : null;
+        if (!state.id && !state.nickname) return null;
+        return {
+          id: state.id,
+          email: state.email,
+          nickname: state.nickname,
+          birthDate: state.birthDate,
+          gender: state.gender,
+          provider: state.provider,
+        };
       },
     }),
     {
@@ -63,6 +62,9 @@ export const useUser = create<UserState>()(
         gender: state.gender,
         provider: state.provider,
       }),
+      onRehydrateStorage: () => () => {
+        setTimeout(() => useUser.setState({ isLoaded: true }), 0);
+      },
     }
   )
 );

--- a/src/shared/ui/Footer.tsx
+++ b/src/shared/ui/Footer.tsx
@@ -169,7 +169,7 @@ export default function Footer() {
 
   const handleNavigation = (path: string) => {
     if (router) {
-      if(condition && (path === '/my-page' || path === '/record')) {
+      if(condition && path === '/record') {
         setErrorBox(condition)
         return;
       }

--- a/src/shared/ui/guard/AuthGuard.tsx
+++ b/src/shared/ui/guard/AuthGuard.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useToken, useUser } from '@/shared/store';
 import { useRefreshToken } from '@/features/refresh/model/useRefreshToken';
 import { notificationTestApi } from '@/features/notification-test/api/notification-test-api';
 import ConfirmModal from '@/shared/ui/ConfirmModal';
+import FullScreenLoader from '@/shared/ui/FullScreenLoader';
 
 interface IAuthGuard {
   children: React.ReactNode
@@ -14,9 +15,14 @@ interface IAuthGuard {
 export function AuthGuard({ children }: IAuthGuard) {
   const router = useRouter();
   const pathname = usePathname();
-  const { getAccessToken, getRefreshToken, isLoaded, errorBox, setErrorBox, clearTokens } = useToken();
+  const { getAccessToken, getRefreshToken, errorBox, setErrorBox, clearTokens } = useToken();
   const { mutate: refreshMutate } = useRefreshToken();
   const notificationTestCalled = useRef(false);
+
+  const [hasHydrated, setHasHydrated] = useState(false);
+  useEffect(() => {
+    setHasHydrated(true);
+  }, []);
 
   const accessToken = getAccessToken();
   const refreshToken = getRefreshToken();
@@ -29,7 +35,7 @@ export function AuthGuard({ children }: IAuthGuard) {
 
   // 토큰 상태 감시 - 토큰이 없으면 로그인 페이지로 이동
   useEffect(() => {
-    if (!isLoaded) return;
+    if (!hasHydrated) return;
 
     if (!accessToken || !refreshToken) {
       clearTokens();
@@ -37,7 +43,7 @@ export function AuthGuard({ children }: IAuthGuard) {
     } else if (pathname === '/login') {
       router.replace('/');
     }
-  }, [isLoaded, accessToken, refreshToken, pathname]);
+  }, [hasHydrated, accessToken, refreshToken, pathname]);
 
   // 테스트 API는 '/' 라우트에서만 한 번 호출
   useEffect(() => {
@@ -66,6 +72,10 @@ export function AuthGuard({ children }: IAuthGuard) {
       if(intervalId) clearInterval(intervalId);
     }
   },[pathname])
+
+  if (!hasHydrated) {
+    return <FullScreenLoader isLoading />;
+  }
 
   return (
     <>

--- a/src/shared/ui/house-hold/EmptyExpenseState.tsx
+++ b/src/shared/ui/house-hold/EmptyExpenseState.tsx
@@ -11,8 +11,9 @@ interface EmptyExpenseStateProps {
 export default function EmptyExpenseState({ dateString }: EmptyExpenseStateProps) {
   const router = useRouter();
   const { getUser } = useUser();
-  const { setErrorBox } = useToken();
+  const { setErrorBox, getAccessToken } = useToken();
   const user = getUser();
+  const accessToken = getAccessToken();
 
   return (
     <div className="flex flex-col items-center justify-center">
@@ -21,7 +22,7 @@ export default function EmptyExpenseState({ dateString }: EmptyExpenseStateProps
       </p>
       <button
         onClick={() => {
-          if (!user?.nickname || user?.nickname.startsWith('guest')) {
+          if (!accessToken || user?.nickname?.startsWith('guest')) {
             setErrorBox(true);
             return;
           }

--- a/src/shared/ui/house-hold/TodayExpenseBox.tsx
+++ b/src/shared/ui/house-hold/TodayExpenseBox.tsx
@@ -28,7 +28,9 @@ export default function TodayExpenseBox({ emotions, expenseCategories }: TodayEx
   const [selectedDate, setSelectedDate] = useState<Date>(TODAY);
   const [showLoginModal, setShowLoginModal] = useState(false);
   const { getUser } = useUser();
+  const { getAccessToken } = useToken();
   const user = getUser();
+  const accessToken = getAccessToken();
 
   const canGoPrev = selectedDate > MIN_DATE;
   const canGoNext = selectedDate < TODAY;
@@ -58,7 +60,7 @@ export default function TodayExpenseBox({ emotions, expenseCategories }: TodayEx
   const dateString = `${selectedDate.getFullYear()}-${String(selectedDate.getMonth() + 1).padStart(2, '0')}-${String(selectedDate.getDate()).padStart(2, '0')}`;
 
   const handleExportClick = () => {
-    if (!user?.nickname || user?.nickname.startsWith('guest')) {
+    if (!accessToken || user?.nickname?.startsWith('guest')) {
       setShowLoginModal(true);
       return;
     }

--- a/src/widgets/asset/AssetContent.tsx
+++ b/src/widgets/asset/AssetContent.tsx
@@ -6,12 +6,14 @@ import Footer from '@/shared/ui/Footer';
 import PageHeader from '@/shared/ui/PageHeader';
 import ConfirmModal from '@/shared/ui/ConfirmModal';
 import { useGetAssets } from '@/entities/get-assets/useGetAssets';
-import { useUser } from '@/shared/store';
+import { useToken, useUser } from '@/shared/store';
 
 export default function AssetContent() {
   const router = useRouter();
   const { getUser } = useUser();
+  const { getAccessToken } = useToken();
   const user = getUser();
+  const accessToken = getAccessToken();
   const [showLoginModal, setShowLoginModal] = useState(false);
 
   const { data: assetsData, isLoading } = useGetAssets({
@@ -23,7 +25,7 @@ export default function AssetContent() {
   const groupedAssets = assetsData?.categories ?? [];
 
   const handleAddAsset = () => {
-    if (!user?.nickname || user?.nickname.startsWith('guest')) {
+    if (!accessToken || user?.nickname?.startsWith('guest')) {
       setShowLoginModal(true);
       return;
     }

--- a/src/widgets/asset/AssetDetailContent.tsx
+++ b/src/widgets/asset/AssetDetailContent.tsx
@@ -89,10 +89,7 @@ export default function AssetDetailContent({ categoryId }: AssetDetailContentPro
       await deleteAssetApi(deleteTargetId);
       setDeleteTargetId(null);
       setSwipedId(null);
-      // 캐시 무효화하여 목록 새로고침
-      await queryClient.invalidateQueries({
-        queryKey: ['assets']
-      });
+      await queryClient.invalidateQueries({ refetchType: 'all' });
     } catch (error) {
       alert('삭제 중 오류가 발생했습니다.');
       setIsDeleting(false);

--- a/src/widgets/calendar/CalendarContent.tsx
+++ b/src/widgets/calendar/CalendarContent.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useToken, useUser } from '@/shared/store';
 import { expenseQueries } from '@/entities/expense';
 import { incomeQueries } from '@/entities/income';
@@ -52,6 +52,12 @@ export default function CalendarContent() {
   const { getUser } = useUser();
   const user = getUser();
   const token = getAccessToken();
+
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.invalidateQueries({ refetchType: 'all' });
+  }, [queryClient]);
 
   const handleAddExpense = () => {
     if (!user?.nickname || user?.nickname.startsWith('guest')) {

--- a/src/widgets/calendar/CalendarContent.tsx
+++ b/src/widgets/calendar/CalendarContent.tsx
@@ -60,7 +60,7 @@ export default function CalendarContent() {
   }, [queryClient]);
 
   const handleAddExpense = () => {
-    if (!user?.nickname || user?.nickname.startsWith('guest')) {
+    if (!token || user?.nickname?.startsWith('guest')) {
       setShowLoginModal(true);
       return;
     }

--- a/src/widgets/house-hold/HouseHoldBoxWrapper.tsx
+++ b/src/widgets/house-hold/HouseHoldBoxWrapper.tsx
@@ -38,7 +38,7 @@ export default function HouseHoldBoxWrapper() {
   const randomNumber = useMemo(() => getRandomNumberByDate(), []);
 
   const handleWeekBoxClick = () => {
-    if (!user?.nickname || user?.nickname.startsWith('guest')) {
+    if (!accessToken || user?.nickname?.startsWith('guest')) {
       setShowLoginModal(true);
       return;
     }

--- a/src/widgets/report/ReportContent.tsx
+++ b/src/widgets/report/ReportContent.tsx
@@ -151,7 +151,7 @@ export default function ReportContent() {
             expense={expense}
             onYearMonthChange={handleYearMonthChange}
             onExpenseDetailClick={() => {
-              if (!user?.nickname || user?.nickname.startsWith('guest')) {
+              if (!token || user?.nickname?.startsWith('guest')) {
                 setErrorBox(true);
                 return;
               }

--- a/src/widgets/report/ReportContent.tsx
+++ b/src/widgets/report/ReportContent.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useToken, useUser } from '@/shared/store';
 import { useIsMounted } from '@/shared/hooks';
 import { useUserGetter } from '@/entities/user';
@@ -38,6 +39,11 @@ export default function ReportContent() {
   const isMounted = useIsMounted();
   const { getAccessToken, isLoaded, setErrorBox } = useToken();
   const token = getAccessToken();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.invalidateQueries({ refetchType: 'all' });
+  }, [queryClient]);
   useUserGetter(token);
   const nickname = useUser((s) => s.nickname);
   const { getUser } = useUser();

--- a/src/widgets/retro/RetroContent.tsx
+++ b/src/widgets/retro/RetroContent.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useToken, useUser } from '@/shared/store';
 import { reportQueries } from '@/entities/report';
 import RetroEmpty from '@/widgets/retro/RetroEmpty';
@@ -22,6 +22,11 @@ export default function RetroContent() {
   const [mounted, setMounted] = useState(false);
   const [showLoginModal, setShowLoginModal] = useState(false);
   useEffect(() => setMounted(true), []);
+
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    queryClient.invalidateQueries({ refetchType: 'all' });
+  }, [queryClient]);
 
   const handleButtonClick = () => {
     if (!hasData && (!user?.nickname || user?.nickname.startsWith('guest'))) {

--- a/src/widgets/retro/RetroContent.tsx
+++ b/src/widgets/retro/RetroContent.tsx
@@ -29,7 +29,7 @@ export default function RetroContent() {
   }, [queryClient]);
 
   const handleButtonClick = () => {
-    if (!hasData && (!user?.nickname || user?.nickname.startsWith('guest'))) {
+    if (!hasData && (!token || user?.nickname?.startsWith('guest'))) {
       setShowLoginModal(true);
       return;
     }

--- a/src/widgets/retro/RetroResultContent.tsx
+++ b/src/widgets/retro/RetroResultContent.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useToken } from '@/shared/store';
 import { reviewQueries } from '@/entities/review';
 import PageHeader from '@/shared/ui/PageHeader';
@@ -18,6 +19,11 @@ export default function RetroResultContent() {
 
   const { getAccessToken } = useToken();
   const token = getAccessToken();
+
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    queryClient.invalidateQueries({ refetchType: 'all' });
+  }, [queryClient]);
 
   const { data, isLoading } = useQuery({
     ...reviewQueries.byDate(token || '', date),


### PR DESCRIPTION
## Summary                                                                                                                                 
  QA  두 가지 핵심 이슈 처리                                                                                                  
                                                                                                                                             
  1. **데이터 변경 후 다른 페이지에 즉시 반영 안 됨** → 새로고침 필요                                                                        
  2. **앱 재진입/페이지 이동 시 로그인 팝업**                                                                   
                                                                                                                                             
  ## 변경 내용                                                                                                                               
                                                                                                                                             
  ### 1. 캐시 무효화 정책 정비                                                                                                               
                                                                                                                                             
  **모든 mutation onSuccess에 광역 invalidate**
  - `useHouseHoldPost`, `usePostIncome`, `useUpdateExpense`, `useUpdateIncome`, `useDeleteExpense`, `useDeleteIncome`, `usePostAsset`, `useUpdateAsset`, AssetDetailContent 인라인 삭제                                                                                           
  - `queryClient.invalidateQueries({ refetchType: 'all' })` — active + inactive 모든 쿼리 즉시 백그라운드 refetch
                                                                                                                                             
  **queryClient 기본 옵션 변경** (`src/shared/api/queryClient.ts`)              
  - `staleTime: 60000` → `staleTime: 0`                                                                                                      
  - `refetchOnMount: 'always'` 추가     
                                                                                                                                             
  **페이지 mount 시 강제 invalidate**                                                                                                        
  - `ReportContent`, `CalendarContent`, `RetroContent`, `RetroResultContent`에 useEffect로 mount 시 invalidate                               
                                                                                                                                             
  **Next.js Router Cache 비활성화** (`next.config.ts`)                                                                                       
  - `experimental.staleTimes: { dynamic: 0, static: 0 }`                        
                                                                                                                                             
  **useUpdateExpense는 hard navigation**                                                                                                     
  - `router.push('/')` → `window.location.href = '/'` 로 변경 → 모든 캐시 비움                                                               
                                                                                                                                             
  ### 2. AuthGuard hydration 깜빡임 해결                                                                                                     
                                                                                                                                             
  **`AuthGuard.tsx`**                                                          
  - `useState + useEffect`로 hydration 완료 시점 추적                                                                                        
  - hydration 완료 전: `FullScreenLoader` 표시 + children 렌더 차단            
  - 완료 후: 정상 children 렌더                                                                                                              
                                                                                                                                             
  **`token-store.ts` / `user-store.ts`**                                       
  - `onRehydrateStorage`에서 `setTimeout`으로 setState → React rerender 보장                                                                 
                                                                                                                                             
  **`user-store.ts`의 `getUser()` 변경**                                                                                                     
  - `isLoaded` 의존 → 실제 데이터(`id`/`nickname`) 유무로 판단                                                                               
                                                                               
  ### 3. 로그인 체크 로직 토큰 기반으로 통일                                                                                                 
                                                                                                                                             
  `user.nickname`만 의존하던 로그인 체크를 토큰 기반으로 변경 (hydration 타이밍과 무관하게 안정적)                                           
                                                                                                                                             
  대상 파일 (7개):                      
  - `TodayExpenseBox`, `CalendarContent`, `AssetContent`, `HouseHoldBoxWrapper`, `RetroContent`, `ReportContent`, `EmptyExpenseState`        
                                                                                                                                             
  ### 4. 게스트 모드 마이페이지 접근 허용                                       
                                                                                                                                             
  `Footer.tsx` — 게스트의 `/my-page` 접근 차단 제거 (안에서 로그인 유도 가능)