### PR TITLE
[FEAT] 회고 기능 고도화 - ui 퍼블리싱

### DIFF
--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -1,36 +1,160 @@
 "use client";
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import PageHeader from '@/shared/ui/PageHeader';
-import { UserBox } from '@/entities/user';
-import CommonFeature from '@/shared/ui/my-page/CommonFeature';
-import { useUser } from '@/shared/store';
-import { AuthGuard } from '@/shared/ui/guard/AuthGuard';
-import { LogoutModal } from '@/features/logout/ui/LogoutModal';
 import Footer from '@/shared/ui/Footer';
-
+import ConfirmModal from '@/shared/ui/ConfirmModal';
+import { AuthGuard } from '@/shared/ui/guard/AuthGuard';
+import { useToken, useUser } from '@/shared/store';
+import { LogoutModal } from '@/features/logout/ui/LogoutModal';
 
 function MyPageContent() {
-  const { getUser } = useUser();
+  const router = useRouter();
+  const { clearTokens } = useToken();
+  const { getUser, clearUser } = useUser();
   const user = getUser();
+
   const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
+  const [isPushNotificationEnabled, setIsPushNotificationEnabled] = useState(false);
+  const [isPushModalOpen, setIsPushModalOpen] = useState(false);
+
+  useEffect(() => {
+    setIsPushNotificationEnabled(localStorage.getItem('isPushNotificationEnabled') === 'true');
+  }, []);
+
+  const handleTogglePush = () => {
+    if (!isPushNotificationEnabled) {
+      setIsPushModalOpen(true);
+      return;
+    }
+    setIsPushNotificationEnabled(false);
+    localStorage.setItem('isPushNotificationEnabled', 'false');
+  };
+
+  const isGuest = user?.nickname?.startsWith('guest');
+
+  const handleAccountClick = () => {
+    if (isGuest) {
+      clearTokens();
+      clearUser();
+      router.push('/login');
+      return;
+    }
+    setIsLogoutModalOpen(true);
+  };
+
+  const providerLabel =
+    user?.provider === 'GOOGLE'
+      ? '구글로 로그인'
+      : user?.provider === 'KAKAO'
+        ? '카카오로 로그인'
+        : '게스트로 로그인';
 
   return (
-    <AuthGuard>
-      <PageHeader title={'마이페이지'} />
-      <UserBox />
-      <CommonFeature title={'푸시 알림'} secondary={'푸시 알림'} />
-      <CommonFeature
-        title={'로그아웃'}
-        secondary={user?.nickname.startsWith('guest') ? '로그인하기' : '로그아웃'}
-        changeLogoutModal={(bool: boolean) =>  setIsLogoutModalOpen(bool)}
-      />
+    <div className="flex min-h-dvh flex-col bg-white pb-30">
+      <PageHeader title="마이페이지" showBack={false} />
+
+      <div className="flex flex-col gap-6.25 pt-2.5">
+        {/* 프로필 카드 */}
+        <div className="px-4">
+          <div className="flex items-center gap-3.75 rounded-[12px] bg-[#F7F8FA] p-4">
+            <div className="relative h-15 w-15 shrink-0">
+              <Image src="/svg/character1.png" alt="profile" fill className="object-contain" />
+            </div>
+            <div className="flex flex-col gap-0.5">
+              <span className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-[#030303]">
+                {user?.nickname ?? '손님'}
+              </span>
+              <span className="text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#353535]">
+                {providerLabel}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* 알림 섹션 */}
+        <section className="flex flex-col gap-2.5 px-4">
+          <h2 className="text-[16px] font-medium leading-normal tracking-[-0.025em] text-[#73787E]">
+            알림
+          </h2>
+          <div className="flex items-center justify-between">
+            <span className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-[#1C1D1F]">
+              푸시 알림
+            </span>
+            <button
+              type="button"
+              onClick={handleTogglePush}
+              className={`flex h-[32px] w-[58px] cursor-pointer items-center rounded-full p-[5px] transition-colors ${
+                isPushNotificationEnabled ? 'justify-end bg-[#13278a]' : 'justify-start bg-[#CACDD2]'
+              }`}
+              aria-label="푸시 알림 토글"
+            >
+              <span className="h-[22px] w-[22px] rounded-full bg-white" />
+            </button>
+          </div>
+        </section>
+
+        {/* 계정 관리 섹션 */}
+        <section className="flex flex-col gap-2.5 px-4">
+          <h2 className="text-[16px] font-medium leading-normal tracking-[-0.025em] text-[#73787E]">
+            계정 관리
+          </h2>
+          <button
+            type="button"
+            onClick={handleAccountClick}
+            className="flex cursor-pointer items-center justify-between"
+          >
+            <span className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-[#1C1D1F]">
+              {isGuest ? '로그인하기' : '로그아웃'}
+            </span>
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M8.7998 18.4L15.1998 12L8.7998 5.59998" stroke="#73787E" strokeWidth="1.86667" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+        </section>
+
+        {/* 회고 관리 섹션 */}
+        <section className="flex flex-col gap-2.5 px-4">
+          <h2 className="text-[16px] font-medium leading-normal tracking-[-0.025em] text-[#73787E]">
+            회고 관리
+          </h2>
+          <button
+            type="button"
+            onClick={() => router.push('/retro/history')}
+            className="flex cursor-pointer items-center justify-between"
+          >
+            <span className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-[#1C1D1F]">
+              회고록
+            </span>
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M8.7998 18.4L15.1998 12L8.7998 5.59998" stroke="#73787E" strokeWidth="1.86667" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+        </section>
+      </div>
+
       <LogoutModal isOpen={isLogoutModalOpen} onClose={setIsLogoutModalOpen} />
+
+      <ConfirmModal
+        isOpen={isPushModalOpen}
+        title="준비중인 기능입니다"
+        message="푸시 알림 기능은 곧 서비스될 예정입니다."
+        confirmText="확인"
+        onConfirm={() => setIsPushModalOpen(false)}
+        noCancel
+      />
+
       <Footer />
-    </AuthGuard>
+    </div>
   );
 }
 
 export default function MyPage() {
-  return <MyPageContent />;
+  return (
+    <AuthGuard>
+      <MyPageContent />
+    </AuthGuard>
+  );
 }

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -12,9 +12,12 @@ import { LogoutModal } from '@/features/logout/ui/LogoutModal';
 
 function MyPageContent() {
   const router = useRouter();
-  const { clearTokens } = useToken();
-  const { getUser, clearUser } = useUser();
-  const user = getUser();
+  const { clearTokens, setErrorBox } = useToken();
+  const isLoaded = useUser((s) => s.isLoaded);
+  const id = useUser((s) => s.id);
+  const nickname = useUser((s) => s.nickname);
+  const provider = useUser((s) => s.provider);
+  const clearUser = useUser((s) => s.clearUser);
 
   const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
   const [isPushNotificationEnabled, setIsPushNotificationEnabled] = useState(false);
@@ -33,7 +36,7 @@ function MyPageContent() {
     localStorage.setItem('isPushNotificationEnabled', 'false');
   };
 
-  const isGuest = user?.nickname?.startsWith('guest');
+  const isGuest = isLoaded && (!id || nickname.startsWith('guest'));
 
   const handleAccountClick = () => {
     if (isGuest) {
@@ -45,12 +48,21 @@ function MyPageContent() {
     setIsLogoutModalOpen(true);
   };
 
-  const providerLabel =
-    user?.provider === 'GOOGLE'
+  const handleRetroHistoryClick = () => {
+    if (isGuest) {
+      setErrorBox(true);
+      return;
+    }
+    router.push('/retro/history');
+  };
+
+  const providerLabel = isGuest
+    ? '게스트로 로그인'
+    : provider === 'GOOGLE'
       ? '구글로 로그인'
-      : user?.provider === 'KAKAO'
+      : provider === 'KAKAO'
         ? '카카오로 로그인'
-        : '게스트로 로그인';
+        : '';
 
   return (
     <div className="flex min-h-dvh flex-col bg-white pb-30">
@@ -65,10 +77,10 @@ function MyPageContent() {
             </div>
             <div className="flex flex-col gap-0.5">
               <span className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-[#030303]">
-                {user?.nickname ?? '손님'}
+                {isLoaded ? nickname : '로딩 중...'}
               </span>
               <span className="text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#353535]">
-                {providerLabel}
+                {isLoaded ? providerLabel : ''}
               </span>
             </div>
           </div>
@@ -85,11 +97,13 @@ function MyPageContent() {
             </span>
             <button
               type="button"
+              role="switch"
+              aria-checked={isPushNotificationEnabled}
               onClick={handleTogglePush}
               className={`flex h-[32px] w-[58px] cursor-pointer items-center rounded-full p-[5px] transition-colors ${
                 isPushNotificationEnabled ? 'justify-end bg-[#13278a]' : 'justify-start bg-[#CACDD2]'
               }`}
-              aria-label="푸시 알림 토글"
+              aria-label="푸시 알림"
             >
               <span className="h-[22px] w-[22px] rounded-full bg-white" />
             </button>
@@ -122,7 +136,7 @@ function MyPageContent() {
           </h2>
           <button
             type="button"
-            onClick={() => router.push('/retro/history')}
+            onClick={handleRetroHistoryClick}
             className="flex cursor-pointer items-center justify-between"
           >
             <span className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-[#1C1D1F]">

--- a/src/app/retro/history/[date]/page.tsx
+++ b/src/app/retro/history/[date]/page.tsx
@@ -1,0 +1,15 @@
+import RetroHistoryDetailContent from '@/widgets/retro-history/RetroHistoryDetailContent';
+import { AuthGuard } from '@/shared/ui/guard/AuthGuard';
+
+interface PageProps {
+  params: Promise<{ date: string }>;
+}
+
+export default async function RetroHistoryDetailPage({ params }: PageProps) {
+  const { date } = await params;
+  return (
+    <AuthGuard>
+      <RetroHistoryDetailContent date={date} />
+    </AuthGuard>
+  );
+}

--- a/src/app/retro/history/page.tsx
+++ b/src/app/retro/history/page.tsx
@@ -1,0 +1,10 @@
+import RetroHistoryContent from '@/widgets/retro-history/RetroHistoryContent';
+import { AuthGuard } from '@/shared/ui/guard/AuthGuard';
+
+export default function RetroHistoryPage() {
+  return (
+    <AuthGuard>
+      <RetroHistoryContent />
+    </AuthGuard>
+  );
+}

--- a/src/shared/constants/retroHistoryMock.ts
+++ b/src/shared/constants/retroHistoryMock.ts
@@ -1,0 +1,78 @@
+export interface RetroHistoryItem {
+  id: number;
+  title: {
+    prefixText: string;
+    highlightText: string;
+    suffixText: string;
+  };
+  options: {
+    situationTagName: string;
+    satisfactionScore: number;
+    nextActionOptionText: string;
+  };
+  result: {
+    feedbackTitle: string;
+    feedbackText: string;
+    guideTitle: string;
+    guideItems: string[];
+  };
+}
+
+export interface RetroHistoryEntry {
+  date: string;
+  items: RetroHistoryItem[];
+}
+
+const SAMPLE_ITEM: RetroHistoryItem = {
+  id: 1,
+  title: {
+    prefixText: '나를 위한 보상보다 ',
+    highlightText: '아쉬움',
+    suffixText: '이 더 컸던 오늘',
+  },
+  options: {
+    situationTagName: '보상 심리',
+    satisfactionScore: 2,
+    nextActionOptionText: '지출 줄이기',
+  },
+  result: {
+    feedbackTitle: '이런 점을 바꿔보면 어떨까요?',
+    feedbackText:
+      '보상 심리는 자연스러운 감정이에요\n힘든 날 나를 챙기고 싶은 마음은 당연하니까요\n다만, 미리 "보상 예산"을 정해두면 쓰고 나면\n아쉬움 대신 뿌듯함이 남을 거예요!',
+    guideTitle: '보상 심리가 생길 땐 이렇게 해보세요',
+    guideItems: [
+      '월 보상 예산 설정하기',
+      '바로 사지 않고 하루 뒤에 다시 생각해보기',
+      '진짜 원하는 건지 스스로 되물어보기',
+    ],
+  },
+};
+
+export const RETRO_HISTORY_MOCK: RetroHistoryEntry[] = [
+  { date: '2026-05-01', items: [{ ...SAMPLE_ITEM, id: 11 }] },
+  { date: '2026-05-09', items: [{ ...SAMPLE_ITEM, id: 21 }] },
+  { date: '2026-05-14', items: [{ ...SAMPLE_ITEM, id: 31 }] },
+  {
+    date: '2026-05-17',
+    items: [
+      { ...SAMPLE_ITEM, id: 41 },
+      { ...SAMPLE_ITEM, id: 42, options: { ...SAMPLE_ITEM.options, satisfactionScore: 4 } },
+      { ...SAMPLE_ITEM, id: 43, options: { ...SAMPLE_ITEM.options, satisfactionScore: 5 } },
+    ],
+  },
+  {
+    date: '2026-05-24',
+    items: [
+      { ...SAMPLE_ITEM, id: 51 },
+      { ...SAMPLE_ITEM, id: 52, options: { ...SAMPLE_ITEM.options, satisfactionScore: 3 } },
+    ],
+  },
+];
+
+export function getRetroHistoryByDate(date: string): RetroHistoryItem[] {
+  return RETRO_HISTORY_MOCK.find((entry) => entry.date === date)?.items ?? [];
+}
+
+export function getRetroHistoryDates(): string[] {
+  return RETRO_HISTORY_MOCK.map((entry) => entry.date);
+}

--- a/src/shared/ui/ConfirmModal.tsx
+++ b/src/shared/ui/ConfirmModal.tsx
@@ -33,20 +33,45 @@ export default function ConfirmModal({
     <>
       <div
         className={`fixed inset-0 right-0 left-0 z-50 mx-auto max-w-md bg-black transition-opacity duration-200 ${
-          isOpen ? 'opacity-50 pointer-events-auto' : 'opacity-0 pointer-events-none'
+          isOpen ? 'opacity-30 pointer-events-auto' : 'opacity-0 pointer-events-none'
         }`}
         aria-hidden="true"
       />
-      {type === 'loginCheck' || type === 'logoutCheck' || type === 'deleteCheck' ? (
+      {type === 'deleteCheck' ? (
+        <div
+          className={`fixed top-1/2 right-0 left-0 z-60 mx-auto flex h-[222px] w-[283px] -translate-y-1/2 flex-col items-center rounded-[10px] bg-white px-[21px] pt-[49px] pb-5 transition-opacity duration-200 ${visibilityClass}`}
+        >
+          <div className="flex flex-col items-center gap-[5px]">
+            <span className="text-center text-[16px] font-semibold leading-normal tracking-[-0.025em] text-black">
+              {title}
+            </span>
+            <span className="text-center text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#474C52]">
+              {secondary ?? message}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="mt-8 flex h-10 w-[241px] cursor-pointer items-center justify-center rounded-[8px] bg-[#EB1C1C] text-[16px] font-medium leading-normal tracking-[-0.025em] text-white"
+          >
+            {confirmText}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="mt-[7px] cursor-pointer text-[16px] font-medium leading-normal tracking-[-0.025em] text-[#73787E]"
+          >
+            {cancelText}
+          </button>
+        </div>
+      ) : type === 'loginCheck' || type === 'logoutCheck' ? (
         <div
           className={`box__container__2 fixed top-1/2 right-0 left-0 z-60 mx-auto h-auto w-70.75 -translate-y-1/2 rounded-[10px] bg-white px-5.25 pt-12.25 pb-5 transition-opacity duration-200 ${visibilityClass}`}
         >
           <span className={'mb-1 block text-center text-[14px] font-bold'}>{title}</span>
           <span className={'text-ray-600 mb-8 block text-center text-[14px]'}>{secondary}</span>
           <div className={'button__wrapper flex flex-col gap-2'}>
-            <button className={`rounded-[8px] py-2 text-[14px] text-white ${
-              type === 'deleteCheck' ? 'bg-[#eb1c1c] hover:bg-[#d41a1a]' : 'bg-[#13278a] hover:bg-[#0f1f66]'
-            }`} onClick={onConfirm}>
+            <button className="rounded-[8px] py-2 text-[14px] text-white bg-[#13278a] hover:bg-[#0f1f66]" onClick={onConfirm}>
               {confirmText}
             </button>
             <button className={'text-[14px] py-2 text-black rounded-[8px]'} onClick={onCancel}>

--- a/src/shared/ui/ConfirmModal.tsx
+++ b/src/shared/ui/ConfirmModal.tsx
@@ -56,13 +56,15 @@ export default function ConfirmModal({
           >
             {confirmText}
           </button>
-          <button
-            type="button"
-            onClick={onCancel}
-            className="mt-[7px] cursor-pointer text-[16px] font-medium leading-normal tracking-[-0.025em] text-[#73787E]"
-          >
-            {cancelText}
-          </button>
+          {!noCancel && onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="mt-[7px] cursor-pointer text-[16px] font-medium leading-normal tracking-[-0.025em] text-[#73787E]"
+            >
+              {cancelText}
+            </button>
+          )}
         </div>
       ) : type === 'loginCheck' || type === 'logoutCheck' ? (
         <div

--- a/src/shared/ui/Footer.tsx
+++ b/src/shared/ui/Footer.tsx
@@ -177,7 +177,7 @@ export default function Footer() {
 
   const handleNavigation = (path: string) => {
     if (router) {
-      if(condition && (path === '/record' || path === '/my-page')) {
+      if(condition && path === '/record') {
         setErrorBox(true)
         return;
       }

--- a/src/widgets/asset/AssetDetailContent.tsx
+++ b/src/widgets/asset/AssetDetailContent.tsx
@@ -214,9 +214,9 @@ export default function AssetDetailContent({ categoryId }: AssetDetailContentPro
       <ConfirmModal
         isOpen={deleteTargetId !== null}
         type="deleteCheck"
-        title="자산을 삭제하시겠어요?"
-        secondary="이 작업은 되돌릴 수 없습니다."
-        confirmText="삭제"
+        title="삭제하시겠어요?"
+        secondary="삭제한 항목은 되돌릴 수 없어요."
+        confirmText="확인"
         cancelText="취소"
         onConfirm={handleDeleteConfirm}
         onCancel={() => setDeleteTargetId(null)}

--- a/src/widgets/calendar/DateBottomSheet.tsx
+++ b/src/widgets/calendar/DateBottomSheet.tsx
@@ -351,9 +351,9 @@ export default function DateBottomSheet({
 
       <ConfirmModal
         isOpen={deleteTarget !== null}
-        title={deleteTarget?.type === 'income' ? '수입을 삭제하시겠어요?' : '지출을 삭제하시겠어요?'}
-        message="이 작업은 되돌릴 수 없습니다."
-        confirmText="삭제"
+        title="삭제하시겠어요?"
+        secondary="삭제한 항목은 되돌릴 수 없어요."
+        confirmText="확인"
         cancelText="취소"
         isDangerous
         onConfirm={handleDeleteConfirm}

--- a/src/widgets/calendar/DateBottomSheet.tsx
+++ b/src/widgets/calendar/DateBottomSheet.tsx
@@ -351,11 +351,11 @@ export default function DateBottomSheet({
 
       <ConfirmModal
         isOpen={deleteTarget !== null}
+        type="deleteCheck"
         title="삭제하시겠어요?"
         secondary="삭제한 항목은 되돌릴 수 없어요."
         confirmText="확인"
         cancelText="취소"
-        isDangerous
         onConfirm={handleDeleteConfirm}
         onCancel={() => setDeleteTarget(null)}
       />

--- a/src/widgets/export/ExportContent.tsx
+++ b/src/widgets/export/ExportContent.tsx
@@ -159,9 +159,9 @@ export default function ExportContent() {
       <ConfirmModal
         isOpen={deleteTargetId !== null}
         type="deleteCheck"
-        title="지출을 삭제하시겠어요?"
-        secondary="이 작업은 되돌릴 수 없습니다."
-        confirmText="삭제"
+        title="삭제하시겠어요?"
+        secondary="삭제한 항목은 되돌릴 수 없어요."
+        confirmText="확인"
         cancelText="취소"
         onConfirm={handleDeleteConfirm}
         onCancel={() => setDeleteTargetId(null)}

--- a/src/widgets/retro-history/RetroDeleteModal.tsx
+++ b/src/widgets/retro-history/RetroDeleteModal.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect } from 'react';
+
 interface RetroDeleteModalProps {
   isOpen: boolean;
   onConfirm: () => void;
@@ -7,6 +9,15 @@ interface RetroDeleteModalProps {
 }
 
 export default function RetroDeleteModal({ isOpen, onConfirm, onClose }: RetroDeleteModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
   return (
     <>
       <div
@@ -17,15 +28,25 @@ export default function RetroDeleteModal({ isOpen, onConfirm, onClose }: RetroDe
         onClick={onClose}
       />
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="retro-delete-title"
+        aria-describedby="retro-delete-desc"
         className={`fixed top-1/2 right-0 left-0 z-60 mx-auto flex h-[180px] w-[300px] -translate-y-1/2 flex-col items-center justify-between rounded-[10px] bg-white px-4 py-[30px] transition-opacity duration-200 ${
           isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
         }`}
       >
         <div className="flex flex-col items-center gap-[3px]">
-          <h2 className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-black">
+          <h2
+            id="retro-delete-title"
+            className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-black"
+          >
             삭제하시겠어요?
           </h2>
-          <p className="text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#474C52]">
+          <p
+            id="retro-delete-desc"
+            className="text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#474C52]"
+          >
             삭제 후 복구할 수 없어요
           </p>
         </div>

--- a/src/widgets/retro-history/RetroDeleteModal.tsx
+++ b/src/widgets/retro-history/RetroDeleteModal.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+interface RetroDeleteModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export default function RetroDeleteModal({ isOpen, onConfirm, onClose }: RetroDeleteModalProps) {
+  return (
+    <>
+      <div
+        className={`fixed inset-0 right-0 left-0 z-50 mx-auto max-w-md bg-black transition-opacity duration-200 ${
+          isOpen ? 'opacity-30 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        }`}
+        aria-hidden="true"
+        onClick={onClose}
+      />
+      <div
+        className={`fixed top-1/2 right-0 left-0 z-60 mx-auto flex h-[180px] w-[300px] -translate-y-1/2 flex-col items-center justify-between rounded-[10px] bg-white px-4 py-[30px] transition-opacity duration-200 ${
+          isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        }`}
+      >
+        <div className="flex flex-col items-center gap-[3px]">
+          <h2 className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-black">
+            삭제하시겠어요?
+          </h2>
+          <p className="text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#474C52]">
+            삭제 후 복구할 수 없어요
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onConfirm}
+          className="flex h-[44px] w-[260px] cursor-pointer items-center justify-center rounded-[10px] bg-[#13278A]"
+        >
+          <span className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-white">
+            확인
+          </span>
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/widgets/retro-history/RetroHistoryContent.tsx
+++ b/src/widgets/retro-history/RetroHistoryContent.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import PageHeader from '@/shared/ui/PageHeader';
+import MonthPickerBottomSheet, { type YearMonth } from '@/widgets/report/MonthPickerBottomSheet';
+import { getRetroHistoryDates } from '@/shared/constants/retroHistoryMock';
+
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+function pad(n: number) {
+  return String(n).padStart(2, '0');
+}
+
+interface CalendarCell {
+  date: string;
+  day: number;
+  isCurrentMonth: boolean;
+}
+
+function buildCalendar(year: number, month: number): CalendarCell[] {
+  const firstDay = new Date(year, month - 1, 1);
+  const lastDay = new Date(year, month, 0);
+  const startWeekday = firstDay.getDay();
+  const daysInMonth = lastDay.getDate();
+
+  const prevMonth = month === 1 ? 12 : month - 1;
+  const prevYear = month === 1 ? year - 1 : year;
+  const prevMonthLastDay = new Date(prevYear, prevMonth, 0).getDate();
+
+  const nextMonth = month === 12 ? 1 : month + 1;
+  const nextYear = month === 12 ? year + 1 : year;
+
+  const cells: CalendarCell[] = [];
+
+  for (let i = startWeekday - 1; i >= 0; i--) {
+    const day = prevMonthLastDay - i;
+    cells.push({
+      date: `${prevYear}-${pad(prevMonth)}-${pad(day)}`,
+      day,
+      isCurrentMonth: false,
+    });
+  }
+
+  for (let day = 1; day <= daysInMonth; day++) {
+    cells.push({
+      date: `${year}-${pad(month)}-${pad(day)}`,
+      day,
+      isCurrentMonth: true,
+    });
+  }
+
+  while (cells.length % 7 !== 0) {
+    const day = cells.length - (startWeekday + daysInMonth) + 1;
+    cells.push({
+      date: `${nextYear}-${pad(nextMonth)}-${pad(day)}`,
+      day,
+      isCurrentMonth: false,
+    });
+  }
+
+  return cells;
+}
+
+export default function RetroHistoryContent() {
+  const router = useRouter();
+  const today = useMemo(() => new Date(), []);
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth() + 1);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [pendingYear, setPendingYear] = useState(year);
+  const [pendingMonth, setPendingMonth] = useState(month);
+
+  const cells = useMemo(() => buildCalendar(year, month), [year, month]);
+  const historySet = useMemo(() => new Set(getRetroHistoryDates()), []);
+
+  const currentSystemYear = new Date().getFullYear();
+  const monthLabel = year === currentSystemYear ? `${month}월` : `${year}년 ${month}월`;
+
+  const handleOpenPicker = () => {
+    setPendingYear(year);
+    setPendingMonth(month);
+    setIsPickerOpen(true);
+  };
+
+  const handlePickerChange = (ym: YearMonth) => {
+    setPendingYear(ym.year);
+    setPendingMonth(ym.month);
+  };
+
+  const handlePickerConfirm = () => {
+    setYear(pendingYear);
+    setMonth(pendingMonth);
+    setIsPickerOpen(false);
+  };
+
+  const handleDayClick = (cell: CalendarCell) => {
+    if (!cell.isCurrentMonth) return;
+    if (!historySet.has(cell.date)) return;
+    router.push(`/retro/history/${cell.date}`);
+  };
+
+  return (
+    <div className="flex min-h-dvh flex-col bg-white">
+      <PageHeader title="회고록" />
+
+      <div className="px-4 pt-4 pb-3">
+        <button
+          type="button"
+          onClick={handleOpenPicker}
+          className="flex cursor-pointer items-center gap-1"
+          aria-expanded={isPickerOpen}
+        >
+          <span className="text-[22px] font-semibold leading-normal tracking-[-0.025em] text-[#030303]">
+            {monthLabel}
+          </span>
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 20 20"
+            fill="none"
+            className={`transition-transform ${isPickerOpen ? 'rotate-180' : ''}`}
+          >
+            <path d="M5 7.5L10 12.5L15 7.5" stroke="#73787E" strokeWidth="1.33" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      </div>
+
+      <div className="grid grid-cols-7 bg-[#F7F8FA]">
+        {WEEKDAYS.map((wd) => (
+          <div
+            key={wd}
+            className="flex h-[31px] items-center justify-center text-[14px] font-medium tracking-[-0.025em] text-[#474C52]"
+          >
+            {wd}
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7">
+        {cells.map((cell, idx) => {
+          const hasRetro = cell.isCurrentMonth && historySet.has(cell.date);
+          return (
+            <button
+              key={idx}
+              type="button"
+              onClick={() => handleDayClick(cell)}
+              disabled={!hasRetro}
+              className={`flex h-[106px] flex-col items-start gap-2.5 px-[5px] py-2 ${
+                hasRetro ? 'cursor-pointer' : 'cursor-default'
+              }`}
+            >
+              <span
+                className={`flex h-[25px] w-[25px] items-center justify-center text-[14px] font-medium tracking-[-0.025em] ${
+                  cell.isCurrentMonth ? 'text-[#1C1D1F]' : 'text-[#9FA4A8]'
+                }`}
+              >
+                {cell.day}
+              </span>
+              {hasRetro && (
+                <div className="flex w-[25px] items-center justify-center">
+                  <span className="h-2 w-2 rounded-full bg-[#13278A]" />
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <MonthPickerBottomSheet
+        isOpen={isPickerOpen}
+        selectedYear={pendingYear}
+        selectedMonth={pendingMonth}
+        onChange={handlePickerChange}
+        onConfirm={handlePickerConfirm}
+        onClose={() => setIsPickerOpen(false)}
+      />
+    </div>
+  );
+}

--- a/src/widgets/retro-history/RetroHistoryDetailContent.tsx
+++ b/src/widgets/retro-history/RetroHistoryDetailContent.tsx
@@ -20,6 +20,10 @@ export default function RetroHistoryDetailContent({ date }: RetroHistoryDetailCo
   const touchStartX = useRef(0);
 
   useEffect(() => {
+    setCurrentIndex((prev) => Math.min(prev, Math.max(items.length - 1, 0)));
+  }, [items.length]);
+
+  useEffect(() => {
     if (!isMenuOpen) return;
     const handler = (e: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
@@ -63,7 +67,7 @@ export default function RetroHistoryDetailContent({ date }: RetroHistoryDetailCo
 
   const handleDeleteConfirm = () => {
     setIsDeleteModalOpen(false);
-    router.back();
+    router.replace('/retro/history');
   };
 
   if (!item) {

--- a/src/widgets/retro-history/RetroHistoryDetailContent.tsx
+++ b/src/widgets/retro-history/RetroHistoryDetailContent.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getRetroHistoryByDate, type RetroHistoryItem } from '@/shared/constants/retroHistoryMock';
+import RetroDeleteModal from './RetroDeleteModal';
+
+interface RetroHistoryDetailContentProps {
+  date: string;
+}
+
+export default function RetroHistoryDetailContent({ date }: RetroHistoryDetailContentProps) {
+  const router = useRouter();
+  const items = useMemo(() => getRetroHistoryByDate(date), [date]);
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const touchStartX = useRef(0);
+
+  useEffect(() => {
+    if (!isMenuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    };
+    const timer = window.setTimeout(() => {
+      document.addEventListener('click', handler);
+    }, 0);
+    return () => {
+      window.clearTimeout(timer);
+      document.removeEventListener('click', handler);
+    };
+  }, [isMenuOpen]);
+
+  const item: RetroHistoryItem | undefined = items[currentIndex];
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    touchStartX.current = e.clientX;
+  };
+
+  const handlePointerUp = (e: React.PointerEvent) => {
+    const diff = touchStartX.current - e.clientX;
+    if (Math.abs(diff) < 50) return;
+    if (diff > 0) {
+      setCurrentIndex((i) => Math.min(items.length - 1, i + 1));
+    } else {
+      setCurrentIndex((i) => Math.max(0, i - 1));
+    }
+  };
+
+  const handleEdit = () => {
+    setIsMenuOpen(false);
+    router.push(`/retro/survey?date=${date}&id=${item?.id}&mode=edit`);
+  };
+
+  const handleDelete = () => {
+    setIsMenuOpen(false);
+    setIsDeleteModalOpen(true);
+  };
+
+  const handleDeleteConfirm = () => {
+    setIsDeleteModalOpen(false);
+    router.back();
+  };
+
+  if (!item) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center">
+        <p className="text-[14px] text-[#9FA4A8]">회고 데이터를 찾을 수 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-dvh flex-col bg-white">
+      {/* 헤더 */}
+      <div className="relative flex h-14 items-center justify-center">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="absolute left-4 flex h-7 w-7 cursor-pointer items-center justify-center"
+          aria-label="뒤로"
+        >
+          <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+            <path d="M17 6L9 14L17 22" stroke="#27282C" strokeWidth="1.87" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+        <h1 className="text-[20px] font-semibold leading-normal tracking-[-0.025em] text-[#030303]">
+          회고
+        </h1>
+        <div ref={menuRef} className="absolute right-4 z-20">
+          <button
+            type="button"
+            onClick={() => setIsMenuOpen((v) => !v)}
+            className="flex h-7 w-7 cursor-pointer items-center justify-center"
+            aria-label="메뉴"
+          >
+            <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+              <circle cx="14" cy="7" r="1.5" fill="#27282C" />
+              <circle cx="14" cy="14" r="1.5" fill="#27282C" />
+              <circle cx="14" cy="21" r="1.5" fill="#27282C" />
+            </svg>
+          </button>
+          {isMenuOpen && (
+            <div className="absolute right-0 top-full mt-2 flex w-[100px] flex-col overflow-hidden rounded-[10.46px] border-[1.31px] border-[#E5E5E5] bg-white">
+              <button
+                type="button"
+                onClick={handleDelete}
+                className="flex h-[34px] w-full cursor-pointer items-center bg-white px-[15px] py-[5px] text-[16px] font-medium leading-[150%] tracking-[-0.025em] text-[#474C52]"
+              >
+                삭제
+              </button>
+              <div className="h-px w-full bg-[#E5E5E5]" />
+              <button
+                type="button"
+                onClick={handleEdit}
+                className="flex h-[34px] w-full cursor-pointer items-center bg-white px-[15px] py-[5px] text-[16px] font-medium leading-[150%] tracking-[-0.025em] text-[#474C52]"
+              >
+                수정
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div
+        className="overflow-hidden"
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        style={{ touchAction: 'pan-y' }}
+      >
+        <div
+          className="flex transition-transform duration-300 ease-out"
+          style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+        >
+          {items.map((it) => (
+            <div key={it.id} className="flex w-full shrink-0 flex-col gap-10 px-4 pt-5 pb-25">
+              {/* 섹션 1: 타이틀 + 결과 카드 */}
+              <div className="flex flex-col gap-5">
+                <p className="whitespace-pre-line text-[22px] font-bold leading-normal tracking-[-0.025em] text-[#1C1D1F]">
+                  {it.title.prefixText}
+                  <br />
+                  <span className="text-[#13278A]">{it.title.highlightText}</span>
+                  {it.title.suffixText}
+                </p>
+
+                <div
+                  className="flex flex-col gap-1.5 rounded-xl p-4"
+                  style={{
+                    background:
+                      'linear-gradient(98.51deg, #F7F8FA -1.34%, #ECF2FC 70.89%, #D8E8FF 119.81%) padding-box, linear-gradient(98.51deg, #6B9CE5 0%, #13278A 100%) border-box',
+                    border: '1px solid transparent',
+                  }}
+                >
+                  <div className="flex items-center gap-2.5">
+                    <p className="w-[75px] whitespace-nowrap text-[16px] font-medium leading-normal tracking-[-0.025em] text-[#474C52]">
+                      소비 이유:
+                    </p>
+                    <p className="text-[16px] font-semibold leading-normal tracking-[-0.025em] text-[#030303]">
+                      {it.options.situationTagName}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2.5">
+                    <p className="w-[75px] whitespace-nowrap text-[16px] font-medium leading-normal tracking-[-0.025em] text-[#474C52]">
+                      만족도:
+                    </p>
+                    <div className="flex gap-1.5">
+                      {[1, 2, 3, 4, 5].map((star) => (
+                        <svg key={star} width="20" height="20" viewBox="0 0 20 19" fill="none">
+                          <path
+                            d="M9.51074 0L11.7559 6.90983H19.0213L13.1435 11.1803L15.3886 18.0902L9.51074 13.8197L3.63289 18.0902L5.87803 11.1803L0.000177383 6.90983H7.2656L9.51074 0Z"
+                            fill={star <= it.options.satisfactionScore ? '#13278A' : '#CACDD2'}
+                          />
+                        </svg>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2.5">
+                    <p className="w-[75px] whitespace-nowrap text-[16px] font-medium leading-normal tracking-[-0.025em] text-[#474C52]">
+                      내일의 다짐:
+                    </p>
+                    <p className="text-[16px] font-semibold leading-normal tracking-[-0.025em] text-[#030303]">
+                      {it.options.nextActionOptionText}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* 섹션 2: 💡 피드백 */}
+              <div className="flex w-full flex-col gap-3.75">
+                <div className="flex items-center gap-1">
+                  <span className="text-[20px]">💡</span>
+                  <p className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-[#030303]">
+                    {it.result.feedbackTitle}
+                  </p>
+                </div>
+                <div className="w-full rounded-xl bg-[#F7F8FA] p-4">
+                  <p className="whitespace-pre-line text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#27282C]">
+                    {it.result.feedbackText}
+                  </p>
+                </div>
+              </div>
+
+              {/* 섹션 3: 📋 가이드 */}
+              <div className="flex w-full flex-col gap-3.75">
+                <div className="flex items-center gap-1">
+                  <span className="text-[20px]">📋</span>
+                  <p className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-[#030303]">
+                    {it.result.guideTitle}
+                  </p>
+                </div>
+                <div className="flex w-full flex-col gap-3 rounded-xl bg-[#F7F8FA] p-4">
+                  {it.result.guideItems.map((g, idx) => (
+                    <div key={`${it.id}-${idx}`} className="flex items-center gap-1.5">
+                      <span className="flex h-3.75 w-3.75 shrink-0 items-center justify-center rounded-full bg-[#13278A]">
+                        <svg width="9" height="9" viewBox="0 0 9 9" fill="none">
+                          <path
+                            d="M1.5 4.5L3.5 6.5L7.5 2"
+                            stroke="white"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      </span>
+                      <p className="text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#27282C]">
+                        {g}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {items.length > 1 && (
+        <div className="flex justify-center gap-1.5 pb-6">
+          {items.map((it, idx) => (
+            <span
+              key={it.id}
+              className={`h-1.5 w-1.5 rounded-full transition-colors ${
+                idx === currentIndex ? 'bg-[#13278A]' : 'bg-[#CACDD2]'
+              }`}
+            />
+          ))}
+        </div>
+      )}
+
+      <RetroDeleteModal
+        isOpen={isDeleteModalOpen}
+        onConfirm={handleDeleteConfirm}
+        onClose={() => setIsDeleteModalOpen(false)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary                            
  - 마이페이지에 "회고록" 진입 추가 → 캘린더 → 상세 페이지 UI 퍼블리싱 (mock 데이터 기반)                               
  - 회고록 상세 페이지: 점3개 메뉴(삭제/수정) + 좌우 스와이프 페이지네이션(transition-transform 슬라이드 모션)                                                                                                          
                                                                                                                                             
  ## 주요 변경                                                                                                                               
  - `src/app/my-page/page.tsx` — 마이페이지 재구성, 회고록 메뉴 추가                                                                         
  - `src/app/retro/history/page.tsx`, `src/app/retro/history/[date]/page.tsx` — 라우트 진입점                                                
  - `src/widgets/retro-history/` — RetroHistoryContent(캘린더), RetroHistoryDetailContent(상세 + 스와이프), RetroDeleteModal                 
  - `src/shared/constants/retroHistoryMock.ts` — mock 데이터 (5/1, 5/9, 5/14, 5/17×3, 5/24×2)                                                
  - `src/shared/ui/ConfirmModal.tsx` — `deleteCheck` 타입 신설 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 회고록을 월 단위 캘린더로 조회할 수 있는 히스토리 페이지 추가
  * 선택한 날짜의 회고 항목을 스와이프로 넘겨보며 상세 조회 가능
  * 마이페이지 UI 개선 및 기능 재구성

* **스타일**
  * 삭제 확인 모달 메시지 및 버튼 스타일 통일
  * 모달 배경 투명도 조정으로 시각적 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feel-log/feellog-frontend/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

  ## 추가 수정 (CodeRabbit 리뷰 반영 + 게스트 접근 정리)                              
                                                                                      
  ### CodeRabbit 리뷰 반영                                                            
  - `DateBottomSheet.tsx` — `ConfirmModal`에 `type="deleteCheck"` 누락되어 통일된 삭제
   모달 디자인이 안 떴던 실 버그 수정                                                 
  - `ConfirmModal.tsx` — `deleteCheck` 분기에 `{!noCancel && onCancel && ...}` 조건 추가                                                                                
  - `RetroDeleteModal.tsx` — `role="dialog"`, `aria-modal`,                     
  `aria-labelledby/describedby`, ESC 키 닫기 접근성 추가 (문구는 회고록 별도 정책으로 유지)                                                                               
  - `RetroHistoryDetailContent.tsx` — 삭제 후 `router.back()` →                       
  `router.replace('/retro/history')`로 목적지 고정, `items.length` 변경 시 `currentIndex` 경계값 보정                                                          
  - `my-page/page.tsx` — `isGuest` 판별 로직 통일 (`isLoaded && (!id || nickname.startsWith('guest'))`), `providerLabel` 분기 정리, 푸시 알림 토글에 `role="switch"`, `aria-checked` 추가                                                
                                        
  ### 게스트 접근 흐름 정리                                                           
  - `Footer.tsx` — `/my-page` 차단 제거 (게스트도 마이페이지에서 로그인 가능해야 함)  
  - `my-page/page.tsx` — 회고록 메뉴는 게스트 클릭 시 로그인 모달 표시 후 차단 (Footer의 `/record` 차단과 동일 패턴)                                               
                                                                                
  ### 추가 폴리싱                       
  - `my-page` 스토어 접근을 `useUser` 셀렉터 방식으로 통일 (Footer와 일관)            
  - 닉네임 hydration 전엔 `"로딩 중..."` 표시 (의미 없는 fallback 대신 명시적 상태 표시)                                                                               
                                                                                      
  ### 미적용                            
  - 회고록 삭제 모달 문구 통일 제안 — 회고록은 별도 디자인/문구로 유지하는 사용자 결정에 따라 스킵