### PR TITLE
[FIX] 온보딩 로직 수정

### DIFF
--- a/src/shared/ui/TextBallon.tsx
+++ b/src/shared/ui/TextBallon.tsx
@@ -9,7 +9,7 @@
  */
 export function TextBallon({ text, type, place, width} : { text: string; type: "TOP" | "BOTTOM"; place: number; width: number }) {
     return (
-        <div className="text__ballon bg-[#ecf2fb] absolute z-[120] left-0 right-0 mx-auto text-center rounded-full text-[14px] font-semibold text-[#13278a] py-2" style={{ width: `${width}px`, top: type === "TOP" ? `${place}px` : 'auto', bottom: type === "BOTTOM" ? `${place}px` : `auto`  }}>
+        <div className="text__ballon bg-[#ecf2fb] absolute z-[120] left-0 right-0 mx-auto text-center rounded-full text-[14px] font-semibold text-[#13278a] py-1.5" style={{ width: `${width}px`, top: type === "TOP" ? `${place}px` : 'auto', bottom: type === "BOTTOM" ? `${place}px` : `auto`  }}>
             <span>{text}</span>
             <div className="triangle translate-y-[5px] w-[14px] h-[12px] bg-[#ecf2fb] absolute left-0 right-0 mx-auto" style={{ clipPath: 'polygon(0% 0%,100% 0%, 50% 100%)'}}></div>
         </div>

--- a/src/widgets/house-hold/HouseHoldDim.tsx
+++ b/src/widgets/house-hold/HouseHoldDim.tsx
@@ -68,31 +68,31 @@ export function HouseHoldDim({ isRendered, changeFalse, boxOn, boxOff, secondBox
                 {
                     currentIndex === 0 &&
                     <>
-                        <div role="button__dimmed" className="w-[60px] h-[60px] bg-[#13278a] rounded-full absolute z-[120] bottom-[61px] left-0 right-0 mx-auto bottom-[61px] flex justify-center items-center border border-dashed border-white">
+                        <div role="button__dimmed" className="w-[60px] h-[60px] bg-[#13278a] rounded-full absolute z-[120] bottom-[61px] left-0 right-0 mx-auto bottom-[61px] flex justify-center items-center border-dashed border-white" style={{ borderWidth: '2px'}}>
                             <Image src={"/svg/icon_plus.svg"} alt="plus" width={30} height={30} />
                         </div>
-                        <TextBallon text={"오늘의 지출을 기록해보세요"} type={"BOTTOM"} place={142} width={188} />  
+                        <TextBallon text={"오늘의 지출을 기록해 보세요"} type={"BOTTOM"} place={142} width={188} />  
                     </>
                 }
                 {
                     currentIndex === 1 &&
-                    <TextBallon text={"일간, 주간, 월간 지출을 확인할 수 있어요"} type={"TOP"} place={150} width={253} />
+                    <TextBallon text={"일간, 주간, 월간 지출을 확인할 수 있어요"} type={"TOP"} place={70} width={253} />
                 }
                 {
                     currentIndex === 2 &&
-                    <TextBallon text={"회고를 통해 오늘의 소비를 되돌아보세요"} type={"BOTTOM"} place={290} width={253} />
+                    <TextBallon text={"회고를 통해 오늘의 소비를 되돌아보세요"} type={"BOTTOM"} place={270} width={253} />
                 }
                 {
                 currentIndex! > 0 && typeof(currentIndex) === 'number' &&
                     <button onClick={() => setCurrentIndex((prev) => prev! - 1)} className="absolute z-[120] text-white flex gap-3 items-center flex-row-reverse left-4 bottom-[37px]">
-                        <span>이전</span>
+                        <span className="text-[18px]">이전</span>
                         <Image src={"/svg/right.svg"} alt="left" className="rotate-180" width={8} height={8} />
                     </button>
                 }
                 {
                 currentIndex! < 2 && typeof(currentIndex) === 'number' &&
                     <button onClick={() => setCurrentIndex((prev) => prev! + 1)} className="absolute z-[120] text-white flex gap-3 items-center right-4 bottom-[37px]">
-                        <span>다음</span>
+                        <span className="text-[18px]">다음</span>
                         <Image src={"/svg/right.svg"} alt="left" width={8} height={8} />
                     </button>
                 }


### PR DESCRIPTION
이전, 다음 버튼 폰트 18px인지 체크

말풍선 둥글기 수정

사용자가 처음 진입 시에만 온보딩 화면 보이고 그 후로는 안보여야 함

온보딩 지출 버튼 스트로크 2px로 수정

오늘의 지출을 기록해보세요 띄어쓰기 수정

말풍선과 밑에 컨텐츠 사이 간격 더 붙게 수정

온보딩 3은 말풍선이 안들어가있음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 말풍선 높이를 조정했습니다.
  * 단계 안내 UI의 원형 아이콘 테두리 스타일을 개선했습니다.
  * 안내 문구의 띄어쓰기를 수정했습니다.
  * 말풍선 위치를 정확하게 조정했습니다.

* **스타일**
  * 이전/다음 버튼의 텍스트 크기를 조정했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feel-log/feellog-frontend/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->