### PR TITLE
[FEAT] 리포트 기능 고도화

### DIFF
--- a/src/entities/report/model/report-schema.ts
+++ b/src/entities/report/model/report-schema.ts
@@ -17,7 +17,7 @@ const CommentSchema = z.object({
 });
 
 const ConsecutiveCommentSchema = z.object({
-  months: z.number(),
+  months: z.number().int().positive(),
   names: z.array(z.string()),
   message: z.string(),
 });

--- a/src/entities/report/model/report-schema.ts
+++ b/src/entities/report/model/report-schema.ts
@@ -16,10 +16,19 @@ const CommentSchema = z.object({
   message: z.string(),
 });
 
+const ConsecutiveCommentSchema = z.object({
+  months: z.number(),
+  names: z.array(z.string()),
+  message: z.string(),
+});
+
 const CommentsSchema = z.object({
   categoryChange: CommentSchema,
   emotionTrend: CommentSchema,
   situationTrend: CommentSchema,
+  categoryConsecutive: ConsecutiveCommentSchema.optional(),
+  emotionConsecutive: ConsecutiveCommentSchema.optional(),
+  situationConsecutive: ConsecutiveCommentSchema.optional(),
 });
 
 const CategoryItemSchema = z.object({

--- a/src/shared/ui/AutoFitText.tsx
+++ b/src/shared/ui/AutoFitText.tsx
@@ -8,10 +8,9 @@ const MIN_FONT = 10;
 interface AutoFitTextProps {
   children: ReactNode;
   className?: string;
-  deps?: unknown[];
 }
 
-export default function AutoFitText({ children, className, deps = [] }: AutoFitTextProps) {
+export default function AutoFitText({ children, className }: AutoFitTextProps) {
   const ref = useRef<HTMLParagraphElement>(null);
   const [fontSize, setFontSize] = useState(MAX_FONT);
 
@@ -19,17 +18,22 @@ export default function AutoFitText({ children, className, deps = [] }: AutoFitT
     const el = ref.current;
     if (!el) return;
 
-    let size = MAX_FONT;
-    el.style.fontSize = `${size}px`;
-
-    while (el.scrollWidth > el.clientWidth && size > MIN_FONT) {
-      size -= 0.5;
+    const recalc = () => {
+      let size = MAX_FONT;
       el.style.fontSize = `${size}px`;
-    }
+      while (el.scrollWidth > el.clientWidth && size > MIN_FONT) {
+        size -= 0.5;
+        el.style.fontSize = `${size}px`;
+      }
+      setFontSize(size);
+    };
 
-    setFontSize(size);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
+    recalc();
+
+    const observer = new ResizeObserver(recalc);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [children]);
 
   return (
     <p ref={ref} style={{ fontSize: `${fontSize}px` }} className={className}>

--- a/src/shared/ui/AutoFitText.tsx
+++ b/src/shared/ui/AutoFitText.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+
+const MAX_FONT = 16;
+const MIN_FONT = 10;
+
+interface AutoFitTextProps {
+  children: ReactNode;
+  className?: string;
+  deps?: unknown[];
+}
+
+export default function AutoFitText({ children, className, deps = [] }: AutoFitTextProps) {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const [fontSize, setFontSize] = useState(MAX_FONT);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    let size = MAX_FONT;
+    el.style.fontSize = `${size}px`;
+
+    while (el.scrollWidth > el.clientWidth && size > MIN_FONT) {
+      size -= 0.5;
+      el.style.fontSize = `${size}px`;
+    }
+
+    setFontSize(size);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return (
+    <p ref={ref} style={{ fontSize: `${fontSize}px` }} className={className}>
+      {children}
+    </p>
+  );
+}

--- a/src/widgets/report/CategoryChart.tsx
+++ b/src/widgets/report/CategoryChart.tsx
@@ -125,7 +125,6 @@ export default function CategoryChart({ categories, year, month, consecutiveMess
         {consecutiveMessage && (
           <AutoFitText
             className="whitespace-nowrap font-medium leading-normal tracking-[-0.025em] text-[#73787E]"
-            deps={[consecutiveMessage]}
           >
             {consecutiveMessage}
           </AutoFitText>

--- a/src/widgets/report/CategoryChart.tsx
+++ b/src/widgets/report/CategoryChart.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import AutoFitText from '@/shared/ui/AutoFitText';
 import type { CategoryItem } from '@/shared/constants/reportMockData';
 
 type CategoryChartCategory = CategoryItem & { id?: number };
@@ -10,6 +11,7 @@ interface CategoryChartProps {
   categories: CategoryChartCategory[];
   year?: number;
   month?: number;
+  consecutiveMessage?: string;
 }
 
 function DonutChart({ categories }: { categories: CategoryChartCategory[] }) {
@@ -107,7 +109,7 @@ function DonutChart({ categories }: { categories: CategoryChartCategory[] }) {
   );
 }
 
-export default function CategoryChart({ categories, year, month }: CategoryChartProps) {
+export default function CategoryChart({ categories, year, month, consecutiveMessage }: CategoryChartProps) {
   const [expanded, setExpanded] = useState(false);
 
   if (categories.length === 0) return null;
@@ -116,9 +118,19 @@ export default function CategoryChart({ categories, year, month }: CategoryChart
 
   return (
     <div className="flex flex-col gap-5 rounded-[12px] bg-[#F7F8FA] py-5 px-4">
-      <h2 className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
-        카테고리별 지출 항목
-      </h2>
+      <div className="flex flex-col gap-2">
+        <h2 className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#030303]">
+          카테고리별 지출 항목
+        </h2>
+        {consecutiveMessage && (
+          <AutoFitText
+            className="whitespace-nowrap font-medium leading-normal tracking-[-0.025em] text-[#73787E]"
+            deps={[consecutiveMessage]}
+          >
+            {consecutiveMessage}
+          </AutoFitText>
+        )}
+      </div>
 
 
       <DonutChart categories={categories} />

--- a/src/widgets/report/EmotionList.tsx
+++ b/src/widgets/report/EmotionList.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import AutoFitText from '@/shared/ui/AutoFitText';
 import EmotionIcon from '@/shared/ui/EmotionIcon';
 import type { EmotionItem } from '@/shared/constants/reportMockData';
 
@@ -11,9 +12,10 @@ interface EmotionListProps {
   emotions: EmotionListItem[];
   year?: number;
   month?: number;
+  consecutiveMessage?: string;
 }
 
-export default function EmotionList({ emotions, year, month }: EmotionListProps) {
+export default function EmotionList({ emotions, year, month, consecutiveMessage }: EmotionListProps) {
   const [expanded, setExpanded] = useState(false);
   const visibleEmotions = expanded ? emotions.slice(0, 5) : emotions.slice(0, 3);
 
@@ -37,9 +39,19 @@ export default function EmotionList({ emotions, year, month }: EmotionListProps)
 
   return (
     <div className="flex flex-col gap-7.5 rounded-[12px] bg-[#F7F8FA] py-5 px-4">
-      <h2 className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#1C1D1F]">
-        감정별 지출 항목
-      </h2>
+      <div className="flex flex-col gap-2">
+        <h2 className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#1C1D1F]">
+          감정별 지출 항목
+        </h2>
+        {consecutiveMessage && (
+          <AutoFitText
+            className="whitespace-nowrap font-medium leading-normal tracking-[-0.025em] text-[#73787E]"
+            deps={[consecutiveMessage]}
+          >
+            {consecutiveMessage}
+          </AutoFitText>
+        )}
+      </div>
 
       <div className="flex flex-col gap-3.75">
         {visibleEmotions.map((item, index) => (

--- a/src/widgets/report/EmotionList.tsx
+++ b/src/widgets/report/EmotionList.tsx
@@ -46,7 +46,6 @@ export default function EmotionList({ emotions, year, month, consecutiveMessage 
         {consecutiveMessage && (
           <AutoFitText
             className="whitespace-nowrap font-medium leading-normal tracking-[-0.025em] text-[#73787E]"
-            deps={[consecutiveMessage]}
           >
             {consecutiveMessage}
           </AutoFitText>

--- a/src/widgets/report/ReportContent.tsx
+++ b/src/widgets/report/ReportContent.tsx
@@ -21,6 +21,13 @@ import { AuthGuard } from '@/shared/ui/guard/AuthGuard';
 
 const CATEGORY_COLORS = ['#13278A', '#1BC590', '#FFDB72', '#E5E5E5', '#FFFFFF'];
 
+function withColon(comment?: { names: string[]; message: string }): string | undefined {
+  if (!comment) return undefined;
+  const first = comment.names[0];
+  if (!first) return comment.message;
+  return comment.message.replace(` ${first}`, `: ${first}`);
+}
+
 export default function ReportContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -166,9 +173,22 @@ export default function ReportContent() {
           {hasData ? (
             <>
               <ReportInsights userName={userName} insights={insights} />
-              <CategoryChart categories={categories} year={year} month={month} />
-              <EmotionList emotions={emotions} year={year} month={month} />
-              <SituationTags situations={situations} />
+              <CategoryChart
+                categories={categories}
+                year={year}
+                month={month}
+                consecutiveMessage={withColon(data?.comments.categoryConsecutive)}
+              />
+              <EmotionList
+                emotions={emotions}
+                year={year}
+                month={month}
+                consecutiveMessage={withColon(data?.comments.emotionConsecutive)}
+              />
+              <SituationTags
+                situations={situations}
+                consecutiveMessage={withColon(data?.comments.situationConsecutive)}
+              />
             </>
           ) : (
             <ReportEmpty />

--- a/src/widgets/report/SituationTags.tsx
+++ b/src/widgets/report/SituationTags.tsx
@@ -168,7 +168,6 @@ export default function SituationTags({ situations, consecutiveMessage }: Situat
         {consecutiveMessage && (
           <AutoFitText
             className="whitespace-nowrap font-medium leading-normal tracking-[-0.025em] text-[#73787E]"
-            deps={[consecutiveMessage]}
           >
             {consecutiveMessage}
           </AutoFitText>

--- a/src/widgets/report/SituationTags.tsx
+++ b/src/widgets/report/SituationTags.tsx
@@ -1,7 +1,9 @@
+import AutoFitText from '@/shared/ui/AutoFitText';
 import type { ReportSituationItem } from '@/entities/report/model/report-schema';
 
 interface SituationTagsProps {
   situations: ReportSituationItem[];
+  consecutiveMessage?: string;
 }
 
 interface SlotConfig {
@@ -135,7 +137,7 @@ function buildRenderInfos(items: ReportSituationItem[]): (RenderInfo | null)[] {
   });
 }
 
-export default function SituationTags({ situations }: SituationTagsProps) {
+export default function SituationTags({ situations, consecutiveMessage }: SituationTagsProps) {
   if (situations.length === 0) {
     return (
       <div className="flex flex-col rounded-[12px] border border-[#F0F0F0] bg-[#F7F8FA] pt-5 pb-24.75 px-4">
@@ -159,9 +161,19 @@ export default function SituationTags({ situations }: SituationTagsProps) {
 
   return (
     <div className="flex flex-col gap-2.5 rounded-[12px] border border-[#F0F0F0] bg-[#F7F8FA] py-5">
-      <h2 className="px-4 text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#1C1D1F]">
-        자주 선택한 상황 태그
-      </h2>
+      <div className="flex flex-col gap-2 px-4">
+        <h2 className="text-[20px] font-semibold leading-normal tracking-[-0.5px] text-[#1C1D1F]">
+          자주 선택한 상황 태그
+        </h2>
+        {consecutiveMessage && (
+          <AutoFitText
+            className="whitespace-nowrap font-medium leading-normal tracking-[-0.025em] text-[#73787E]"
+            deps={[consecutiveMessage]}
+          >
+            {consecutiveMessage}
+          </AutoFitText>
+        )}
+      </div>
 
       <div className="relative mx-auto h-66.5 w-80">
         {items.map((situation, index) => {


### PR DESCRIPTION
## Summary                                                                                                                                 
  - 백엔드 `GET /api/v1/reports/monthly` 응답에 신규 추가된 `categoryConsecutive` / `emotionConsecutive` / `situationConsecutive` 필드 연동  
  - 카테고리/감정/상황 차트 각 카드 상단에 "N개월 연속 ... : {대상명}" 패턴 인사이트 문구 노출                                               
  - 1개월만 1위 케이스는 자동 미노출, 공동 1위 / 3개 이상 케이스는 백엔드 message 활용                                                       
                                                                                                                                             
  ## API 연동                                                                                                                                
  | 필드 | 위치 |                                                                                                                            
  |---|---|                                                                                                                                  
  | `comments.categoryConsecutive` | `CategoryChart` 제목 아래 |                                                                             
  | `comments.emotionConsecutive` | `EmotionList` 제목 아래 |                                                                                
  | `comments.situationConsecutive` | `SituationTags` 제목 아래 |                                                                            
                                                                           
  
## 주요 변경                                                                                                                                  
                  
  - src/entities/report/model/report-schema.ts — ConsecutiveCommentSchema 신규 + CommentsSchema에 3개 필드(optional) 추가                    
  - src/widgets/report/CategoryChart.tsx / EmotionList.tsx / SituationTags.tsx — consecutiveMessage prop 추가, 제목 아래 회색 한 줄 표시
  - src/widgets/report/ReportContent.tsx — withColon 헬퍼로 백엔드 message의 첫 대상명 앞에 :  삽입 후 prop 전달
  - src/shared/ui/AutoFitText.tsx 신규 — 16px → 10px 자동 축소 공용 컴포넌트. 메시지가 컨테이너 폭을 넘으면 한 줄 유지하면서 폰트만 줄임 (ReportInsights의 기존 패턴을 공용화)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 보고서의 카테고리, 감정, 상황 섹션에 연속 인사이트 메시지 표시 기능 추가
  * 텍스트 너비에 자동으로 조정되는 폰트 기능 추가로 더 나은 반응형 디자인 지원

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feel-log/feellog-frontend/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->