### PR TITLE
[FEAT] 푸시알림 고도화 기능 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "embla-carousel-react": "^8.6.0",
+        "firebase": "^12.13.0",
         "lucide-react": "^1.8.0",
         "mathjs": "^15.2.0",
         "next": "16.2.3",
@@ -1356,6 +1357,617 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@firebase/ai": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.12.0.tgz",
+      "integrity": "sha512-b+OL4vdyiSLZL/7dLd67V55CjKJvU9MpNmwnday7eA6GG2+J4iwUEsEHgw0/jKY3A41FfkF0SrnYFvtKbQZ65A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-types": "0.8.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.12.tgz",
+      "integrity": "sha512-FT+HoNp1NdaZ/N26hCwV3WbxS1m6gTn3p2QRBQ3KH7YqyCQqJx0iT7126RgVk68/Rq+9DeL/zCFnHZ0C4u1nLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.3.tgz",
+      "integrity": "sha512-aJ4DfubWfTO8/2vhEhIAizOoOmiycESTU32e+OUgbWcS/G3PA4Vxlr/9zaiN2wfUG2AptQ7DTvj00tyuFZP5Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.3.tgz",
+      "integrity": "sha512-L3AKIRTJxT9b7cDUH3OyV8gWTnmW3vYkwdzRsukWt4kbPBTct12xalnyvHDkm1lKkr+cQq/4uzBx1bOWsQ2ciw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.3",
+        "@firebase/app-check-types": "0.5.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.12.tgz",
+      "integrity": "sha512-Pe513OBerK/CIBxz4/za9atd5MsZtd6DzHz4cmqkvkrcDWhQChAoHBpZ3McuZNuSP8YZiKwfX/J1frR07l15/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.12",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.1.tgz",
+      "integrity": "sha512-/1nkKY/MicI+I9WWcx6R4NKs77AaW9NQ0IwsFdUBomWrW0/cXEmopfM2dtLm2oI1qG6z6vom3CXZDHJIJXoMuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.6.tgz",
+      "integrity": "sha512-KDJ/GAf/rt7galOpn3DRb2buFfGkZCsHTryKjXDG0eeRnok4+2B4nnkMOMdjRnPkElmcJv2Ao0vEA6kp5m98PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.1",
+        "@firebase/auth-types": "0.13.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.0.tgz",
+      "integrity": "sha512-ar9sNOJh5poQCSMSVlnVE8eo8+usTD1POWDCv65omkKUvnFMcdXaQ7J/e7WGKqJzcEMgiezSX/TZiKHZkItMbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.14.1.tgz",
+      "integrity": "sha512-PouS0NJZ3NYOZE/tPDvXa8VUeJ10Ll//7jIdFvMYdhQkd/P3O7nlqhyoTmY0h8Xa9hxg+H0j6gxUytJcoZ9YOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "@firebase/webchannel-wrapper": "1.0.6",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.9.tgz",
+      "integrity": "sha512-NPtBuFr79BbIQJXFWhW4xFC6rBksK8/ewqCTYbbAYfZBDDx0/iHTUj4WpKi5D4d0Pn2Md/3T/e5V9379G5N/Zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.14.1",
+        "@firebase/firestore-types": "3.0.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.4.tgz",
+      "integrity": "sha512-oB5rpm2Emxn2+IS1gRelAeT/5tSZMwM/KhqC5LnJsmTNnS1ZDhD7ZMZNgCI8vchTW6PbaXIwEnpUryGuIQsNbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging-interop-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.4.tgz",
+      "integrity": "sha512-Be+MwhseVf/eFAZwGrFJGok6S7cmsLrAPK8MgyM8LjM0MewTsx2n01WOOca9jio1UsCZOJ0aVyQobnINcdNuIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.4",
+        "@firebase/functions-types": "0.6.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-types": "0.5.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.26",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.26.tgz",
+      "integrity": "sha512-lHVTO9uLofymHVWkYeUtMddIPcmJvSzVbHRB88W6XKfxbcKF+p3QrfqKhDxremSB4NQjUla1Gwn7d9umSMmt/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/messaging-interop-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.26.tgz",
+      "integrity": "sha512-fn0XvWOfK4tsDLSipwJUW9Cp6ahWA6z+iJHxZ0pHp9MzMSUNQx85yuxZAuI7gkGXfqs7+DqEDHyyS7jDGswrmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.12.26",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.4.tgz",
+      "integrity": "sha512-wrzITQq+xw5LtygX7O0fu43/k9ABQ4x5H9/sR5m1SbNnhIRI5xd3+raSNJaJkYC4BUhM9A4ZNSnyR2sjhxnb2Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.3.tgz",
+      "integrity": "sha512-ggGKAaLy9YNOvpFoQZgm5p5SiFw3ZFtwti08dojnBQmQicpThTxvG5xZMSpCTYMj2o3gM/yK9CVd2w+kZub8YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.24.tgz",
+      "integrity": "sha512-EWZTt6fJ7YmPHodQNsSxAIDZY2x8P5kRPvXAc5CmzzBm+NyPFhODbfDsNllDXDL8jlzp50bVWjDY+BXepZS9Mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/remote-config": "0.8.3",
+        "@firebase/remote-config-types": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-types": "0.8.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -1393,6 +2005,37 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
@@ -2481,6 +3124,69 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -5339,7 +6045,6 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -8702,6 +9407,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -8813,6 +9530,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/firebase": {
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.13.0.tgz",
+      "integrity": "sha512-iutR8ejvAqk6qUClnsPz3U3VIjTWp243AX4cD3iifak5t56to1J29xUIQgSDDzaAqKvhshZerzSahwMQj2TlvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.12.0",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.14.12",
+        "@firebase/app-check": "0.11.3",
+        "@firebase/app-check-compat": "0.4.3",
+        "@firebase/app-compat": "0.5.12",
+        "@firebase/app-types": "0.9.5",
+        "@firebase/auth": "1.13.1",
+        "@firebase/auth-compat": "0.6.6",
+        "@firebase/data-connect": "0.7.0",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.14.1",
+        "@firebase/firestore-compat": "0.4.9",
+        "@firebase/functions": "0.13.4",
+        "@firebase/functions-compat": "0.4.4",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.12.26",
+        "@firebase/messaging-compat": "0.2.26",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.8.3",
+        "@firebase/remote-config-compat": "0.2.24",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -8911,6 +9664,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9413,6 +10167,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -9450,6 +10210,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -10682,6 +11448,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -10728,6 +11500,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -12099,6 +12877,30 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
+      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12799,6 +13601,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -14200,7 +15022,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -14737,6 +15558,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webpack-bundle-analyzer": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
@@ -14818,6 +15645,29 @@
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
+    "firebase": "^12.13.0",
     "lucide-react": "^1.8.0",
     "mathjs": "^15.2.0",
     "next": "16.2.3",

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,5 +1,5 @@
-importScripts('https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js');
-importScripts('https://www.gstatic.com/firebasejs/10.12.5/firebase-messaging-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/12.13.0/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/12.13.0/firebase-messaging-compat.js');
 
 firebase.initializeApp({
   apiKey: 'AIzaSyDwhdstQqeiAsuMpUMPElDPure78hDcnQg',

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,22 @@
+importScripts('https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/10.12.5/firebase-messaging-compat.js');
+
+firebase.initializeApp({
+  apiKey: 'AIzaSyDwhdstQqeiAsuMpUMPElDPure78hDcnQg',
+  authDomain: 'feel-log-3de41.firebaseapp.com',
+  projectId: 'feel-log-3de41',
+  storageBucket: 'feel-log-3de41.firebasestorage.app',
+  messagingSenderId: '955303189262',
+  appId: '1:955303189262:web:291a97797f6c4a9cc3955f',
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  const title = payload.notification?.title || '알림';
+  const options = {
+    body: payload.notification?.body || '',
+    icon: '/svg/icon_bell.svg',
+  };
+  self.registration.showNotification(title, options);
+});

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -1,14 +1,18 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import PageHeader from '@/shared/ui/PageHeader';
 import Footer from '@/shared/ui/Footer';
-import ConfirmModal from '@/shared/ui/ConfirmModal';
 import { AuthGuard } from '@/shared/ui/guard/AuthGuard';
 import { useToken, useUser } from '@/shared/store';
 import { LogoutModal } from '@/features/logout/ui/LogoutModal';
+import { notificationQueries } from '@/entities/notification/api/notification-queries';
+import { updateNotificationSettingsApi } from '@/entities/notification/api/notification-api';
+import { postDeviceTokenApi, deleteDeviceTokenApi } from '@/features/post-device-token';
+import { getFcmToken, requestNotificationPermission } from '@/shared/lib/firebase';
 
 function MyPageContent() {
   const router = useRouter();
@@ -20,20 +24,54 @@ function MyPageContent() {
   const clearUser = useUser((s) => s.clearUser);
 
   const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
-  const [isPushNotificationEnabled, setIsPushNotificationEnabled] = useState(false);
-  const [isPushModalOpen, setIsPushModalOpen] = useState(false);
 
-  useEffect(() => {
-    setIsPushNotificationEnabled(localStorage.getItem('isPushNotificationEnabled') === 'true');
-  }, []);
+  const queryClient = useQueryClient();
+  const { data: settings } = useQuery(notificationQueries.settings());
+  const isPushNotificationEnabled = settings?.pushEnabled ?? false;
 
-  const handleTogglePush = () => {
-    if (!isPushNotificationEnabled) {
-      setIsPushModalOpen(true);
-      return;
+  const updateSettingsMutation = useMutation({
+    mutationFn: updateNotificationSettingsApi,
+    onMutate: async (next) => {
+      await queryClient.cancelQueries({ queryKey: notificationQueries.settings().queryKey });
+      const prev = queryClient.getQueryData(notificationQueries.settings().queryKey);
+      queryClient.setQueryData(notificationQueries.settings().queryKey, next);
+      return { prev };
+    },
+    onError: (_err, _next, context) => {
+      if (context?.prev) {
+        queryClient.setQueryData(notificationQueries.settings().queryKey, context.prev);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: notificationQueries.settings().queryKey });
+    },
+  });
+
+  const handleTogglePush = async () => {
+    const next = !isPushNotificationEnabled;
+
+    if (next) {
+      const permission = await requestNotificationPermission();
+      if (permission !== 'granted') {
+        alert('알림 권한을 허용해주세요. (브라우저 설정에서 변경 가능)');
+        return;
+      }
+      const fcmToken = await getFcmToken();
+      if (!fcmToken) {
+        alert('알림 토큰 발급에 실패했어요. 브라우저 알림이 차단되어 있지 않은지 확인해주세요.');
+        return;
+      }
+      localStorage.setItem('fcmToken', fcmToken);
+      await postDeviceTokenApi({ token: fcmToken, deviceType: 'WEB' });
+    } else {
+      const fcmToken = localStorage.getItem('fcmToken');
+      if (fcmToken) {
+        await deleteDeviceTokenApi(fcmToken).catch(() => {});
+        localStorage.removeItem('fcmToken');
+      }
     }
-    setIsPushNotificationEnabled(false);
-    localStorage.setItem('isPushNotificationEnabled', 'false');
+
+    updateSettingsMutation.mutate({ pushEnabled: next });
   };
 
   const isGuest = isLoaded && (!id || nickname.startsWith('guest'));
@@ -150,15 +188,6 @@ function MyPageContent() {
       </div>
 
       <LogoutModal isOpen={isLogoutModalOpen} onClose={setIsLogoutModalOpen} />
-
-      <ConfirmModal
-        isOpen={isPushModalOpen}
-        title="준비중인 기능입니다"
-        message="푸시 알림 기능은 곧 서비스될 예정입니다."
-        confirmText="확인"
-        onConfirm={() => setIsPushModalOpen(false)}
-        noCancel
-      />
 
       <Footer />
     </div>

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -47,31 +47,45 @@ function MyPageContent() {
     },
   });
 
+  const [isToggleProcessing, setIsToggleProcessing] = useState(false);
+
   const handleTogglePush = async () => {
+    if (isToggleProcessing || updateSettingsMutation.isPending) return;
     const next = !isPushNotificationEnabled;
+    setIsToggleProcessing(true);
 
-    if (next) {
-      const permission = await requestNotificationPermission();
-      if (permission !== 'granted') {
-        alert('알림 권한을 허용해주세요. (브라우저 설정에서 변경 가능)');
-        return;
+    try {
+      if (next) {
+        const permission = await requestNotificationPermission();
+        if (permission !== 'granted') {
+          alert('알림 권한을 허용해주세요. (브라우저 설정에서 변경 가능)');
+          return;
+        }
+        const fcmToken = await getFcmToken();
+        if (!fcmToken) {
+          alert('알림 토큰 발급에 실패했어요. 브라우저 알림이 차단되어 있지 않은지 확인해주세요.');
+          return;
+        }
+        await postDeviceTokenApi({ token: fcmToken, deviceType: 'WEB' });
+        localStorage.setItem('fcmToken', fcmToken);
+      } else {
+        const fcmToken = localStorage.getItem('fcmToken');
+        if (fcmToken) {
+          try {
+            await deleteDeviceTokenApi(fcmToken);
+          } catch (error) {
+            console.error('디바이스 토큰 삭제 실패:', error);
+          }
+          localStorage.removeItem('fcmToken');
+        }
       }
-      const fcmToken = await getFcmToken();
-      if (!fcmToken) {
-        alert('알림 토큰 발급에 실패했어요. 브라우저 알림이 차단되어 있지 않은지 확인해주세요.');
-        return;
-      }
-      localStorage.setItem('fcmToken', fcmToken);
-      await postDeviceTokenApi({ token: fcmToken, deviceType: 'WEB' });
-    } else {
-      const fcmToken = localStorage.getItem('fcmToken');
-      if (fcmToken) {
-        await deleteDeviceTokenApi(fcmToken).catch(() => {});
-        localStorage.removeItem('fcmToken');
-      }
+      updateSettingsMutation.mutate({ pushEnabled: next });
+    } catch (error) {
+      console.error('푸시 알림 토글 실패:', error);
+      alert('알림 설정 변경에 실패했어요. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setIsToggleProcessing(false);
     }
-
-    updateSettingsMutation.mutate({ pushEnabled: next });
   };
 
   const isGuest = isLoaded && (!id || nickname.startsWith('guest'));
@@ -137,10 +151,12 @@ function MyPageContent() {
               type="button"
               role="switch"
               aria-checked={isPushNotificationEnabled}
+              aria-disabled={isToggleProcessing || updateSettingsMutation.isPending}
+              disabled={isToggleProcessing || updateSettingsMutation.isPending}
               onClick={handleTogglePush}
-              className={`flex h-[32px] w-[58px] cursor-pointer items-center rounded-full p-[5px] transition-colors ${
+              className={`flex h-[32px] w-[58px] items-center rounded-full p-[5px] transition-colors ${
                 isPushNotificationEnabled ? 'justify-end bg-[#13278a]' : 'justify-start bg-[#CACDD2]'
-              }`}
+              } ${isToggleProcessing || updateSettingsMutation.isPending ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
               aria-label="푸시 알림"
             >
               <span className="h-[22px] w-[22px] rounded-full bg-white" />

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -79,7 +79,7 @@ function MyPageContent() {
           localStorage.removeItem('fcmToken');
         }
       }
-      updateSettingsMutation.mutate({ pushEnabled: next });
+      await updateSettingsMutation.mutateAsync({ pushEnabled: next });
     } catch (error) {
       console.error('푸시 알림 토글 실패:', error);
       alert('알림 설정 변경에 실패했어요. 잠시 후 다시 시도해주세요.');

--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -1,65 +1,139 @@
-import { cn } from "@/shared/lib/utils";
-import { AuthGuard } from "@/shared/ui/guard/AuthGuard";
-import PageHeader from "@/shared/ui/PageHeader";
-import Link from "next/link";
+'use client';
 
-interface NotiMock {
-    time: string;
-    text: string;
-    seeSight: boolean;
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { cn } from '@/shared/lib/utils';
+import { AuthGuard } from '@/shared/ui/guard/AuthGuard';
+import PageHeader from '@/shared/ui/PageHeader';
+import Skeleton from '@/shared/ui/Skeleton';
+import RetroDeleteModal from '@/widgets/retro-history/RetroDeleteModal';
+import { notificationQueries } from '@/entities/notification/api/notification-queries';
+import {
+  deleteAllNotificationsApi,
+  readNotificationApi,
+} from '@/entities/notification/api/notification-api';
+import type { Notification } from '@/entities/notification/model/notification-schema';
+
+function formatRelativeTime(createdAt: string): string {
+  const created = new Date(createdAt);
+  const now = new Date();
+  const diffMs = now.getTime() - created.getTime();
+  const diffMin = Math.floor(diffMs / (1000 * 60));
+  const diffHour = Math.floor(diffMin / 60);
+
+  if (diffMin < 1) return '방금 전';
+  if (diffMin < 60) return `${diffMin}분 전`;
+  if (diffHour < 24) return `${diffHour}시간 전`;
+  return `${created.getMonth() + 1}월 ${created.getDate()}일`;
 }
 
-
 export default function NotiPage() {
+  const queryClient = useQueryClient();
+  const { data: notifications = [], isLoading } = useQuery(notificationQueries.list());
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
-    const noti_mocks: NotiMock[] = [
-        {
-            time: "5분 전",
-            text: "오늘 하루, 어떤 감정으로 소비했는지 들어볼 시간이에요",
-            seeSight: true
-        },
-        {
-            time: "1시간 전",
-            text: "오늘 쓴 돈보다 왜 썼는지 떠올려보는 시간이에요",
-            seeSight: true
-        },
-        {
-            time: "5.3",
-            text: "오늘의 소비와 감정을 가볍게 기록해볼까요?",
-            seeSight: false
-        },
-        {
-            time: "어제",
-            text: "하루를 마무리하며 오늘의 소비를 함께 회고해보세요",
-            seeSight: false
-        }
-    ];
+  const deleteAllMutation = useMutation({
+    mutationFn: deleteAllNotificationsApi,
+    onSuccess: () => {
+      setIsDeleteModalOpen(false);
+      queryClient.invalidateQueries({ queryKey: notificationQueries.all() });
+    },
+    onError: () => {
+      setIsDeleteModalOpen(false);
+      alert('삭제에 실패했어요. 잠시 후 다시 시도해주세요.');
+    },
+  });
 
-    return (
-        <AuthGuard>
-            <PageHeader title={"알림"} />
-            <div className={"noti__content h-[calc(100vh-60px)] flex flex-col"}>
-                {noti_mocks.length === 0 ? 
-                (
-                    <div className="not__noti h-full flex flex-col justify-center items-center">
-                        <span className="text-[18px] font-semibold">알림이 없어요</span>
-                        <span className="text-[12px] text-gray-400 font-medium">푸시 알림을 켜고 알림을 받아보세요</span>
-                    </div>
-                ) : 
-                (
-                    <>
-                        <button className="text-gray-600 self-end text-[14px] mr-3 mb-3 mt-5">전체 삭제</button>
-                        {
-                        noti_mocks.map((noti: NotiMock, index: number) => 
-                            <Link key={index} href="/" className={cn("w-full h-[87px] block px-4 py-4 border-b border-solid border-gray-300", noti.seeSight ? "bg-[#ecf2fb]" : "")}>
-                                <span className="text-[14px] text-gray-500 block pb-[10px]">{noti.time}</span>
-                                <div className="text-gray-800 text-[16px] font-semibold">{noti.text}</div>
-                            </Link>
-                        )
-                        }
-                    </>
+  const readMutation = useMutation({
+    mutationFn: readNotificationApi,
+    onMutate: async (notificationId) => {
+      await queryClient.cancelQueries({ queryKey: notificationQueries.list().queryKey });
+      const prev = queryClient.getQueryData<Notification[]>(notificationQueries.list().queryKey);
+      queryClient.setQueryData<Notification[]>(
+        notificationQueries.list().queryKey,
+        (old) =>
+          old?.map((n) =>
+            n.notificationId === notificationId ? { ...n, isRead: true } : n,
+          ) ?? old,
+      );
+      return { prev };
+    },
+    onError: (_err, _id, context) => {
+      if (context?.prev) {
+        queryClient.setQueryData(notificationQueries.list().queryKey, context.prev);
+      }
+    },
+  });
+
+  const handleNotificationClick = (noti: Notification) => {
+    if (noti.isRead) return;
+    readMutation.mutate(noti.notificationId);
+  };
+
+  return (
+    <AuthGuard>
+      <PageHeader title="알림" />
+      <div className="noti__content flex h-[calc(100vh-60px)] flex-col">
+        {isLoading ? (
+          <>
+            <Skeleton className="mt-5 mr-3 mb-3 h-5 w-16 self-end rounded" />
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="block h-[87px] w-full border-b border-solid border-gray-300 px-4 py-4"
+              >
+                <Skeleton className="mb-2.5 h-4 w-14 rounded" />
+                <Skeleton className="h-5 w-3/4 rounded" />
+              </div>
+            ))}
+          </>
+        ) : notifications.length === 0 ? (
+          <div className="not__noti flex h-full flex-col items-center justify-center">
+            <span className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-[#474C52]">
+              알림이 없어요
+            </span>
+            <span className="text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#9FA4A8]">
+              푸시 알림을 켜고 알림을 받아보세요
+            </span>
+          </div>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={() => setIsDeleteModalOpen(true)}
+              disabled={deleteAllMutation.isPending || notifications.length === 0}
+              className="mt-5 mr-3 mb-3 self-end text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#474C52] disabled:opacity-50"
+            >
+              전체 삭제
+            </button>
+            {notifications.map((noti) => (
+              <button
+                key={noti.notificationId}
+                type="button"
+                onClick={() => handleNotificationClick(noti)}
+                className={cn(
+                  'flex h-[87px] w-full flex-col justify-center gap-2.5 border-b border-solid border-[#CACDD2] px-4 text-left',
+                  !noti.isRead ? 'bg-[#ECF2FB] cursor-pointer' : 'cursor-default bg-white',
                 )}
-            </div>
-        </AuthGuard>
-    )
+              >
+                <span className="text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#73787E]">
+                  {formatRelativeTime(noti.createdAt)}
+                </span>
+                <span className="text-[16px] font-semibold leading-normal tracking-[-0.025em] text-[#1C1D1F]">
+                  {noti.body}
+                </span>
+              </button>
+            ))}
+          </>
+        )}
+      </div>
+
+      <RetroDeleteModal
+        isOpen={isDeleteModalOpen}
+        title="알림을 모두 삭제하시겠어요?"
+        onConfirm={() => deleteAllMutation.mutate()}
+        onClose={() => setIsDeleteModalOpen(false)}
+      />
+    </AuthGuard>
+  );
 }

--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/shared/lib/utils';
 import { AuthGuard } from '@/shared/ui/guard/AuthGuard';
@@ -14,6 +14,8 @@ import {
 } from '@/entities/notification/api/notification-api';
 import type { Notification } from '@/entities/notification/model/notification-schema';
 
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
 function formatRelativeTime(createdAt: string): string {
   const created = new Date(createdAt);
   if (Number.isNaN(created.getTime())) return '';
@@ -25,12 +27,26 @@ function formatRelativeTime(createdAt: string): string {
   if (diffMin < 1) return '방금 전';
   if (diffMin < 60) return `${diffMin}분 전`;
   if (diffHour < 24) return `${diffHour}시간 전`;
-  return `${created.getMonth() + 1}월 ${created.getDate()}일`;
+  return `${created.getMonth() + 1}월 ${created.getDate()}일 ${WEEKDAYS[created.getDay()]}요일`;
 }
 
 export default function NotiPage() {
   const queryClient = useQueryClient();
   const { data: notifications = [], isLoading, isError } = useQuery(notificationQueries.list());
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!notifications.length) return;
+    const now = Date.now();
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    const hasRecent = notifications.some(
+      (n) => now - new Date(n.createdAt).getTime() < DAY_MS,
+    );
+    if (!hasRecent) return;
+
+    const id = window.setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => window.clearInterval(id);
+  }, [notifications]);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const deleteAllMutation = useMutation({

--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -16,6 +16,7 @@ import type { Notification } from '@/entities/notification/model/notification-sc
 
 function formatRelativeTime(createdAt: string): string {
   const created = new Date(createdAt);
+  if (Number.isNaN(created.getTime())) return '';
   const now = new Date();
   const diffMs = now.getTime() - created.getTime();
   const diffMin = Math.floor(diffMs / (1000 * 60));
@@ -29,7 +30,7 @@ function formatRelativeTime(createdAt: string): string {
 
 export default function NotiPage() {
   const queryClient = useQueryClient();
-  const { data: notifications = [], isLoading } = useQuery(notificationQueries.list());
+  const { data: notifications = [], isLoading, isError } = useQuery(notificationQueries.list());
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const deleteAllMutation = useMutation({
@@ -87,6 +88,15 @@ export default function NotiPage() {
               </div>
             ))}
           </>
+        ) : isError ? (
+          <div className="flex h-full flex-col items-center justify-center">
+            <span className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-[#474C52]">
+              알림을 불러오지 못했어요
+            </span>
+            <span className="text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#9FA4A8]">
+              잠시 후 다시 시도해주세요
+            </span>
+          </div>
         ) : notifications.length === 0 ? (
           <div className="not__noti flex h-full flex-col items-center justify-center">
             <span className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-[#474C52]">

--- a/src/entities/notification/api/notification-api.ts
+++ b/src/entities/notification/api/notification-api.ts
@@ -1,11 +1,14 @@
 import { apiClient } from '@/shared/api/api-instance';
-import type {
-  Notification,
-  NotificationSettings,
+import {
+  NotificationListSchema,
+  NotificationSettingsSchema,
+  type Notification,
+  type NotificationSettings,
 } from '@/entities/notification/model/notification-schema';
 
-export function getNotificationsApi(): Promise<Notification[]> {
-  return apiClient<Notification[]>('/api/v1/notifications', { method: 'GET' });
+export async function getNotificationsApi(): Promise<Notification[]> {
+  const data = await apiClient<unknown>('/api/v1/notifications', { method: 'GET' });
+  return NotificationListSchema.parse(data);
 }
 
 export function readAllNotificationsApi(): Promise<void> {
@@ -24,15 +27,17 @@ export function deleteNotificationApi(notificationId: number): Promise<void> {
   return apiClient<void>(`/api/v1/notifications/${notificationId}`, { method: 'DELETE' });
 }
 
-export function getNotificationSettingsApi(): Promise<NotificationSettings> {
-  return apiClient<NotificationSettings>('/api/v1/notification-settings', { method: 'GET' });
+export async function getNotificationSettingsApi(): Promise<NotificationSettings> {
+  const data = await apiClient<unknown>('/api/v1/notification-settings', { method: 'GET' });
+  return NotificationSettingsSchema.parse(data);
 }
 
-export function updateNotificationSettingsApi(
+export async function updateNotificationSettingsApi(
   body: NotificationSettings,
 ): Promise<NotificationSettings> {
-  return apiClient<NotificationSettings>('/api/v1/notification-settings', {
+  const data = await apiClient<unknown>('/api/v1/notification-settings', {
     method: 'PATCH',
     body: JSON.stringify(body),
   });
+  return NotificationSettingsSchema.parse(data);
 }

--- a/src/entities/notification/api/notification-api.ts
+++ b/src/entities/notification/api/notification-api.ts
@@ -1,0 +1,38 @@
+import { apiClient } from '@/shared/api/api-instance';
+import type {
+  Notification,
+  NotificationSettings,
+} from '@/entities/notification/model/notification-schema';
+
+export function getNotificationsApi(): Promise<Notification[]> {
+  return apiClient<Notification[]>('/api/v1/notifications', { method: 'GET' });
+}
+
+export function readAllNotificationsApi(): Promise<void> {
+  return apiClient<void>('/api/v1/notifications/read-all', { method: 'PATCH' });
+}
+
+export function readNotificationApi(notificationId: number): Promise<void> {
+  return apiClient<void>(`/api/v1/notifications/${notificationId}/read`, { method: 'PATCH' });
+}
+
+export function deleteAllNotificationsApi(): Promise<void> {
+  return apiClient<void>('/api/v1/notifications', { method: 'DELETE' });
+}
+
+export function deleteNotificationApi(notificationId: number): Promise<void> {
+  return apiClient<void>(`/api/v1/notifications/${notificationId}`, { method: 'DELETE' });
+}
+
+export function getNotificationSettingsApi(): Promise<NotificationSettings> {
+  return apiClient<NotificationSettings>('/api/v1/notification-settings', { method: 'GET' });
+}
+
+export function updateNotificationSettingsApi(
+  body: NotificationSettings,
+): Promise<NotificationSettings> {
+  return apiClient<NotificationSettings>('/api/v1/notification-settings', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}

--- a/src/entities/notification/api/notification-queries.ts
+++ b/src/entities/notification/api/notification-queries.ts
@@ -1,0 +1,21 @@
+import { queryOptions } from '@tanstack/react-query';
+import {
+  getNotificationSettingsApi,
+  getNotificationsApi,
+} from '@/entities/notification/api/notification-api';
+
+export const notificationQueries = {
+  all: () => ['notification'] as const,
+  list: () =>
+    queryOptions({
+      queryKey: [...notificationQueries.all(), 'list'],
+      queryFn: () => getNotificationsApi(),
+      staleTime: 1000 * 30,
+    }),
+  settings: () =>
+    queryOptions({
+      queryKey: [...notificationQueries.all(), 'settings'],
+      queryFn: () => getNotificationSettingsApi(),
+      staleTime: 1000 * 60,
+    }),
+};

--- a/src/entities/notification/model/notification-schema.ts
+++ b/src/entities/notification/model/notification-schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const NotificationSchema = z.object({
+  notificationId: z.number(),
+  type: z.string(),
+  body: z.string(),
+  isRead: z.boolean(),
+  createdAt: z.string(),
+  readAt: z.string().nullable(),
+});
+
+export const NotificationListSchema = z.array(NotificationSchema);
+
+export const NotificationSettingsSchema = z.object({
+  pushEnabled: z.boolean(),
+});
+
+export type Notification = z.infer<typeof NotificationSchema>;
+export type NotificationSettings = z.infer<typeof NotificationSettingsSchema>;

--- a/src/shared/lib/firebase.ts
+++ b/src/shared/lib/firebase.ts
@@ -31,15 +31,20 @@ export async function requestNotificationPermission(): Promise<NotificationPermi
 }
 
 export async function getFcmToken(): Promise<string | null> {
-  const messaging = getMessagingInstance();
-  if (!messaging || !VAPID_KEY) return null;
+  try {
+    const messaging = getMessagingInstance();
+    if (!messaging || !VAPID_KEY) return null;
 
-  const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js');
-  const token = await getToken(messaging, {
-    vapidKey: VAPID_KEY,
-    serviceWorkerRegistration: registration,
-  });
-  return token || null;
+    const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js');
+    const token = await getToken(messaging, {
+      vapidKey: VAPID_KEY,
+      serviceWorkerRegistration: registration,
+    });
+    return token || null;
+  } catch (error) {
+    console.error('FCM token 발급 실패:', error);
+    return null;
+  }
 }
 
 export function subscribeForegroundMessage(handler: (payload: unknown) => void) {

--- a/src/shared/lib/firebase.ts
+++ b/src/shared/lib/firebase.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { initializeApp, getApps, type FirebaseApp } from 'firebase/app';
+import { getMessaging, getToken, onMessage, type Messaging } from 'firebase/messaging';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+const VAPID_KEY = process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY;
+
+function getFirebaseApp(): FirebaseApp {
+  return getApps().length > 0 ? getApps()[0] : initializeApp(firebaseConfig);
+}
+
+function getMessagingInstance(): Messaging | null {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return null;
+  return getMessaging(getFirebaseApp());
+}
+
+export async function requestNotificationPermission(): Promise<NotificationPermission> {
+  if (typeof window === 'undefined' || !('Notification' in window)) return 'denied';
+  if (Notification.permission === 'granted') return 'granted';
+  if (Notification.permission === 'denied') return 'denied';
+  return await Notification.requestPermission();
+}
+
+export async function getFcmToken(): Promise<string | null> {
+  const messaging = getMessagingInstance();
+  if (!messaging || !VAPID_KEY) return null;
+
+  const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js');
+  const token = await getToken(messaging, {
+    vapidKey: VAPID_KEY,
+    serviceWorkerRegistration: registration,
+  });
+  return token || null;
+}
+
+export function subscribeForegroundMessage(handler: (payload: unknown) => void) {
+  const messaging = getMessagingInstance();
+  if (!messaging) return () => {};
+  return onMessage(messaging, handler);
+}

--- a/src/shared/ui/ConfirmModal.tsx
+++ b/src/shared/ui/ConfirmModal.tsx
@@ -45,9 +45,11 @@ export default function ConfirmModal({
             <span className="text-center text-[16px] font-semibold leading-normal tracking-[-0.025em] text-black">
               {title}
             </span>
-            <span className="text-center text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#474C52]">
-              {secondary ?? message}
-            </span>
+            {(secondary ?? message) && (
+              <span className="text-center text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#474C52]">
+                {secondary ?? message}
+              </span>
+            )}
           </div>
           <button
             type="button"

--- a/src/widgets/retro-history/RetroDeleteModal.tsx
+++ b/src/widgets/retro-history/RetroDeleteModal.tsx
@@ -6,9 +6,17 @@ interface RetroDeleteModalProps {
   isOpen: boolean;
   onConfirm: () => void;
   onClose: () => void;
+  title?: string;
+  description?: string;
 }
 
-export default function RetroDeleteModal({ isOpen, onConfirm, onClose }: RetroDeleteModalProps) {
+export default function RetroDeleteModal({
+  isOpen,
+  onConfirm,
+  onClose,
+  title = '삭제하시겠어요?',
+  description,
+}: RetroDeleteModalProps) {
   useEffect(() => {
     if (!isOpen) return;
     const handler = (e: KeyboardEvent) => {
@@ -41,14 +49,16 @@ export default function RetroDeleteModal({ isOpen, onConfirm, onClose }: RetroDe
             id="retro-delete-title"
             className="text-[18px] font-semibold leading-normal tracking-[-0.025em] text-black"
           >
-            삭제하시겠어요?
+            {title}
           </h2>
-          <p
-            id="retro-delete-desc"
-            className="text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#474C52]"
-          >
-            삭제 후 복구할 수 없어요
-          </p>
+          {description && (
+            <p
+              id="retro-delete-desc"
+              className="text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#474C52]"
+            >
+              {description}
+            </p>
+          )}
         </div>
         <button
           type="button"

--- a/src/widgets/retro-history/RetroDeleteModal.tsx
+++ b/src/widgets/retro-history/RetroDeleteModal.tsx
@@ -40,7 +40,7 @@ export default function RetroDeleteModal({
         aria-modal="true"
         aria-labelledby="retro-delete-title"
         aria-describedby={description ? 'retro-delete-desc' : undefined}
-        className={`fixed top-1/2 right-0 left-0 z-60 mx-auto flex h-[180px] w-[300px] -translate-y-1/2 flex-col items-center justify-between rounded-[10px] bg-white px-4 py-[30px] transition-opacity duration-200 ${
+        className={`fixed top-1/2 right-0 left-0 z-60 mx-auto flex h-[180px] w-[300px] -translate-y-1/2 flex-col items-center justify-center gap-[29px] rounded-[10px] bg-white px-4 py-[30px] transition-opacity duration-200 ${
           isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
         }`}
       >

--- a/src/widgets/retro-history/RetroDeleteModal.tsx
+++ b/src/widgets/retro-history/RetroDeleteModal.tsx
@@ -39,7 +39,7 @@ export default function RetroDeleteModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="retro-delete-title"
-        aria-describedby="retro-delete-desc"
+        aria-describedby={description ? 'retro-delete-desc' : undefined}
         className={`fixed top-1/2 right-0 left-0 z-60 mx-auto flex h-[180px] w-[300px] -translate-y-1/2 flex-col items-center justify-between rounded-[10px] bg-white px-4 py-[30px] transition-opacity duration-200 ${
           isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
         }`}

--- a/src/widgets/retro-history/RetroHistoryDetailContent.tsx
+++ b/src/widgets/retro-history/RetroHistoryDetailContent.tsx
@@ -233,6 +233,7 @@ export default function RetroHistoryDetailContent({ date }: RetroHistoryDetailCo
 
       <RetroDeleteModal
         isOpen={isDeleteModalOpen}
+        description="삭제 후 복구할 수 없어요"
         onConfirm={handleDeleteConfirm}
         onClose={() => setIsDeleteModalOpen(false)}
       />


### PR DESCRIPTION
## Summary                                                                                      
  - 알림 페이지 백엔드 연동 (조회/개별 읽음/전체 삭제)                                            
  - 마이페이지 푸시 토글 — `localStorage` → `notification-settings` API 전환                      
  - Firebase Web SDK 통합으로 실제 FCM 푸시 수신 가능                                             
                                                                                                  
  ## API 연동                                                                                     
  | API | 메서드 | 경로 | 위치 |                                                                  
  |---|---|---|---|                                                                               
  | 알림 목록 조회 | GET | `/api/v1/notifications` | 알림 페이지 |                                
  | 개별 알림 읽음 | PATCH | `/api/v1/notifications/{notificationId}/read` | 알림 카드 클릭 |
  | 알림 전체 삭제 | DELETE | `/api/v1/notifications` | "전체 삭제" 버튼 |                        
  | 알림 설정 조회 | GET | `/api/v1/notification-settings` | 마이페이지 토글 초기값 |             
  | 알림 설정 수정 | PATCH | `/api/v1/notification-settings` | 토글 ON/OFF |                      
  | 디바이스 토큰 등록 | POST | `/api/v1/device-tokens` | 토글 ON 시 |                            
  | 디바이스 토큰 해제 | DELETE | `/api/v1/device-tokens/{token}` | 토글 OFF 시 |                 
                                                                                                  
  ## 주요 변경    
                                                                                                  
  ### 1) 알림 페이지 (`src/app/notification/page.tsx`)                                            
  - mock 데이터 → API 연동
  - 시간 표시 정책 적용 (방금 전 / N분 전 / N시간 전 / M월 D일)                                   
  - 안 읽음(`#ECF2FB`) → 읽음(흰색) 상태 표시, 클릭 시 즉시 흰색으로 전환 (optimistic)            
  - 전체 삭제 시 `RetroDeleteModal` 재사용                                                            
                                                                                                  
  ### 2) 마이페이지 토글 (`src/app/my-page/page.tsx`)                                             
  - `localStorage` 기반 → React Query + `notification-settings` API                               
  - 토글 ON: 알림 권한 요청 → FCM 토큰 발급 → `POST /device-tokens` → settings PATCH              
  - 토글 OFF: `DELETE /device-tokens` → settings PATCH                                            
  - Optimistic update + 실패 시 자동 롤백
  - "준비중" 모달 제거                                                                            
                  
  ### 3) Firebase 통합 (신규)                                                                     
  - `src/shared/lib/firebase.ts` — 초기화, 권한 요청, 토큰 발급, 포그라운드 메시지 구독
  - `public/firebase-messaging-sw.js` — 백그라운드 푸시 수신 서비스 워커                          
  - 환경변수 7개 (`.env.local` + Vercel) — apiKey, authDomain, projectId, storageBucket, messagingSenderId, appId, vapidKey                                                              
                                                                                                  
  ### 4) 알림 entity 신규 (`src/entities/notification/`)                                          
  - `notification-api.ts` — 목록/읽음/삭제/설정 API
  - `notification-queries.ts` — `list`, `settings` query factory                                  
  - `notification-schema.ts` — `Notification`, `NotificationSettings` 타입                        
                                                                                                  
  ### 5) `RetroDeleteModal` 일반화                                                                
  - `title`, `description` props 추가 (기본값 회고록 텍스트)                                      
  - 알림 페이지에서도 재사용 ("알림을 모두 삭제하시겠어요?")
  - `description` 없으면 두 번째 줄 미렌더                                                        
                                                                                                  
  ### 6) `ConfirmModal` 조건부 렌더링 보완                                                        
  - `deleteCheck` 타입에서 `secondary`/`message` 둘 다 없으면 span 안 그림                        
                                                                                                  
  ## 사용자 환경 설정 필요                                                                        
  1. `npm install firebase`                                                                       
  2. `.env.local`에 환경변수 7개 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 푸시 알림 시스템 구현 (Firebase Cloud Messaging 기반)
  * 알림 목록 조회 및 읽음 상태 관리 기능 추가
  * 알림 설정에서 푸시 알림 활성화/비활성화 토글 기능 추가
  * 포그라운드 및 백그라운드 알림 지원

* **Refactor**
  * 알림 페이지 UI 개선 (로딩, 에러, 빈 상태 처리)
  * 상대 시간 포맷 적용으로 알림 시간 표시 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feel-log/feellog-frontend/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->