### PR TITLE
[FIX] 푸시알림 토글 시 에러 수정

### DIFF
--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -48,6 +48,27 @@ function MyPageContent() {
   });
 
   const [isToggleProcessing, setIsToggleProcessing] = useState(false);
+  const autoRegisterTriedRef = useRef(false);
+
+  useEffect(() => {
+    if (!settings?.pushEnabled) return;
+    if (autoRegisterTriedRef.current) return;
+    if (typeof window === 'undefined') return;
+    if (localStorage.getItem('fcmToken')) return;
+    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+
+    autoRegisterTriedRef.current = true;
+    (async () => {
+      try {
+        const fcmToken = await getFcmToken();
+        if (!fcmToken) return;
+        await postDeviceTokenApi({ token: fcmToken, deviceType: 'WEB' });
+        localStorage.setItem('fcmToken', fcmToken);
+      } catch (error) {
+        console.error('FCM 토큰 자동 등록 실패:', error);
+      }
+    })();
+  }, [settings?.pushEnabled]);
 
   const handleTogglePush = async () => {
     if (isToggleProcessing || updateSettingsMutation.isPending) return;

--- a/src/entities/notification/api/notification-api.ts
+++ b/src/entities/notification/api/notification-api.ts
@@ -34,10 +34,9 @@ export async function getNotificationSettingsApi(): Promise<NotificationSettings
 
 export async function updateNotificationSettingsApi(
   body: NotificationSettings,
-): Promise<NotificationSettings> {
-  const data = await apiClient<unknown>('/api/v1/notification-settings', {
+): Promise<void> {
+  await apiClient<unknown>('/api/v1/notification-settings', {
     method: 'PATCH',
     body: JSON.stringify(body),
   });
-  return NotificationSettingsSchema.parse(data);
 }


### PR DESCRIPTION
## 문제                                                                         
                                                                                  
  - 푸시 알림 토글 시 `알림 설정 변경에 실패했어요` alert 발생                    
  - 콘솔에 `ZodError: expected boolean, received undefined` 출력                  
  - 백엔드 `PATCH /api/v1/notification-settings`가 204 No Content(빈 본문)을 반환하는데 프론트에서 `NotificationSettingsSchema.parse()`로 검증해 발생        
                                          
  ## 변경                                                                         
                                                                                  
  - `updateNotificationSettingsApi`에서 응답 zod 검증 제거 (반환 타입 `Promise<void>`)                                                                
  - 로그인 시 `settings.pushEnabled === true`인데 localStorage에 FCM 토큰이 없으면 자동 재발급 및 디바이스 등록                                                   
  - 로그아웃 시 디바이스 토큰은 삭제되지만 백엔드 `pushEnabled`는 유지되는 비대칭 상태 대응

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 푸시 알림이 활성화되면 기기 토큰이 자동으로 등록됩니다.

* **개선 사항**
  * 알림 설정 처리 방식이 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feel-log/feellog-frontend/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->