### PR TITLE
[FEAT] 푸시알림 기능 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-mobile-picker": "^1.2.0",
         "recharts": "^3.8.1",
         "shadcn": "^4.2.0",
+        "sonner": "^2.0.7",
         "swiper": "^12.1.3",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
@@ -14070,6 +14071,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-mobile-picker": "^1.2.0",
     "recharts": "^3.8.1",
     "shadcn": "^4.2.0",
+    "sonner": "^2.0.7",
     "swiper": "^12.1.3",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -12,23 +12,36 @@ firebase.initializeApp({
 
 const messaging = firebase.messaging();
 
+const FALLBACK_URL = '/notification';
+
+function toSafeInternalUrl(rawUrl) {
+  try {
+    const parsed = new URL(rawUrl || FALLBACK_URL, self.location.origin);
+    if (parsed.origin !== self.location.origin) return FALLBACK_URL;
+    return `${parsed.pathname}${parsed.search}${parsed.hash}` || FALLBACK_URL;
+  } catch {
+    return FALLBACK_URL;
+  }
+}
+
 messaging.onBackgroundMessage((payload) => {
   const title = payload.notification?.title || '알림';
   const options = {
     body: payload.notification?.body || '',
     icon: '/svg/icon_bell.svg',
-    data: { url: payload.data?.url || '/notification' },
+    data: { url: toSafeInternalUrl(payload.data?.url) },
   };
   self.registration.showNotification(title, options);
 });
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
-  const targetUrl = event.notification.data?.url || '/notification';
+  const targetUrl = toSafeInternalUrl(event.notification.data?.url);
+  const targetFullUrl = new URL(targetUrl, self.location.origin).href;
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
       for (const client of clientList) {
-        if (client.url.includes(targetUrl) && 'focus' in client) {
+        if (client.url === targetFullUrl && 'focus' in client) {
           return client.focus();
         }
       }

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -17,6 +17,29 @@ messaging.onBackgroundMessage((payload) => {
   const options = {
     body: payload.notification?.body || '',
     icon: '/svg/icon_bell.svg',
+    data: { url: payload.data?.url || '/notification' },
   };
   self.registration.showNotification(title, options);
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = event.notification.data?.url || '/notification';
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      for (const client of clientList) {
+        if (client.url.includes(targetUrl) && 'focus' in client) {
+          return client.focus();
+        }
+      }
+      for (const client of clientList) {
+        if ('focus' in client && 'navigate' in client) {
+          return client.focus().then(() => client.navigate(targetUrl));
+        }
+      }
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(targetUrl);
+      }
+    }),
+  );
 });

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Feel-Log",
-  "short_name": "Feel-Log",
+  "name": "FeelLog",
+  "short_name": "FeelLog",
   "description": "감정에 따른 소비 패턴을 분석하고 추적하는 웹 앱",
   "start_url": "/",
   "scope": "/",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,12 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Toaster } from 'sonner';
 import "./globals.css";
 import BackgroundProvider from './BackgroundProvider';
 import { QueryProvider } from '@/shared/lib/QueryProvider';
 import { KakaoScript } from '@/shared/lib/KakaoScript';
 import { GoogleScript } from '@/shared/lib/GoogleScript';
+import { ForegroundMessageHandler } from '@/shared/lib/ForegroundMessageHandler';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -78,9 +80,11 @@ export default function RootLayout({
         <body className="bg-gray-50 select-none" suppressHydrationWarning>
         <KakaoScript />
         <GoogleScript />
+        <ForegroundMessageHandler />
         <BackgroundProvider>
           {children}
         </BackgroundProvider>
+        <Toaster position="top-center" richColors />
         </body>
       </html>
     </QueryProvider>

--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -138,14 +138,26 @@ export default function NotiPage() {
                 type="button"
                 onClick={() => handleNotificationClick(noti)}
                 className={cn(
-                  'flex h-[87px] w-full flex-col justify-center gap-2.5 border-b border-solid border-[#CACDD2] px-4 text-left',
+                  'flex w-full flex-col justify-center gap-1.5 border-b border-solid border-[#CACDD2] px-4 py-4 text-left',
                   !noti.isRead ? 'bg-[#ECF2FB] cursor-pointer' : 'cursor-default bg-white',
                 )}
               >
                 <span className="text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#73787E]">
                   {formatRelativeTime(noti.createdAt)}
                 </span>
-                <span className="text-[16px] font-semibold leading-normal tracking-[-0.025em] text-[#1C1D1F]">
+                {noti.title && (
+                  <span className="text-[16px] font-semibold leading-normal tracking-[-0.025em] text-[#1C1D1F]">
+                    {noti.title}
+                  </span>
+                )}
+                <span
+                  className={cn(
+                    'leading-normal tracking-[-0.025em]',
+                    noti.title
+                      ? 'text-[14px] font-medium text-[#474C52]'
+                      : 'text-[16px] font-semibold text-[#1C1D1F]',
+                  )}
+                >
                   {noti.body}
                 </span>
               </button>

--- a/src/entities/notification/model/notification-schema.ts
+++ b/src/entities/notification/model/notification-schema.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const NotificationSchema = z.object({
   notificationId: z.number(),
   type: z.string(),
+  title: z.string().nullable(),
   body: z.string(),
   isRead: z.boolean(),
   createdAt: z.string(),

--- a/src/shared/lib/ForegroundMessageHandler.tsx
+++ b/src/shared/lib/ForegroundMessageHandler.tsx
@@ -11,6 +11,18 @@ type FcmPayload = {
   data?: { url?: string };
 };
 
+const FALLBACK_URL = '/notification';
+
+function toSafeInternalPath(rawUrl?: string) {
+  try {
+    const parsed = new URL(rawUrl ?? FALLBACK_URL, window.location.origin);
+    if (parsed.origin !== window.location.origin) return FALLBACK_URL;
+    return `${parsed.pathname}${parsed.search}${parsed.hash}` || FALLBACK_URL;
+  } catch {
+    return FALLBACK_URL;
+  }
+}
+
 export function ForegroundMessageHandler() {
   const router = useRouter();
 
@@ -25,7 +37,7 @@ export function ForegroundMessageHandler() {
       const body = notification?.body;
       if (!title && !body) return;
 
-      const targetUrl = data?.url ?? '/notification';
+      const targetUrl = toSafeInternalPath(data?.url);
       toast.custom(
         (id) => (
           <div

--- a/src/shared/lib/ForegroundMessageHandler.tsx
+++ b/src/shared/lib/ForegroundMessageHandler.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect } from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { subscribeForegroundMessage } from '@/shared/lib/firebase';
+
+type FcmPayload = {
+  notification?: { title?: string; body?: string };
+  data?: { url?: string };
+};
+
+export function ForegroundMessageHandler() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (typeof Notification === 'undefined') return;
+    if (Notification.permission !== 'granted') return;
+
+    const unsubscribe = subscribeForegroundMessage((payload) => {
+      const { notification, data } = payload as FcmPayload;
+      const title = notification?.title;
+      const body = notification?.body;
+      if (!title && !body) return;
+
+      const targetUrl = data?.url ?? '/notification';
+      toast.custom(
+        (id) => (
+          <div
+            onClick={() => {
+              router.push(targetUrl);
+              toast.dismiss(id);
+            }}
+            className="group flex w-89 cursor-pointer items-start gap-3 overflow-hidden rounded-[14px] bg-white p-3.5 shadow-[0_10px_30px_-8px_rgba(19,39,138,0.25)] ring-1 ring-[#ECF2FB] transition-all hover:-translate-y-0.5 hover:shadow-[0_14px_36px_-8px_rgba(19,39,138,0.32)]"
+          >
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-[#13278A] to-[#3F52B5]">
+              <Image src="/svg/icon_bell.svg" alt="" width={18} height={18} className="invert brightness-0" />
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              {title && (
+                <span className="truncate text-[14px] font-semibold leading-normal tracking-[-0.025em] text-[#1C1D1F]">
+                  {title}
+                </span>
+              )}
+              {body && (
+                <span className="line-clamp-2 text-[13px] font-medium leading-snug tracking-[-0.025em] text-[#474C52]">
+                  {body}
+                </span>
+              )}
+            </div>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+              className="mt-1 shrink-0 text-[#9FA4A8] transition-transform group-hover:translate-x-0.5"
+            >
+              <path
+                d="M8.7998 18.4L15.1998 12L8.7998 5.59998"
+                stroke="currentColor"
+                strokeWidth="1.86667"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
+        ),
+        { duration: 5000 },
+      );
+    });
+
+    return unsubscribe;
+  }, [router]);
+
+  return null;
+}


### PR DESCRIPTION
## 변경                                                                              
                                                                                       
  ### 포그라운드 토스트                                                                
  - `sonner` 라이브러리 도입 (`Toaster` 컴포넌트 layout에 등록)                        
  - `ForegroundMessageHandler` 컴포넌트 신규 — FCM 포그라운드 메시지 구독              
  - 앱 사용 중 푸시 수신 시 화면 상단에 인앱 토스트 표시
  - 토스트 본체 클릭 시 알림 페이지로 이동    
                                                                                       
  ### 백그라운드 OS 알림                                                               
  - `firebase-messaging-sw.js`에 `notificationclick` 이벤트 핸들러 추가                                                                                  
  - 클릭 시 이미 열린 PWA 창 focus 또는 새 창 open
                                                                                       
  ### 알림 페이지 두 줄 렌더링                                                         
  - `NotificationSchema`에 `title: z.string().nullable()` 추가
  - 알림 페이지에서 title + body 두 줄 표시                                            
  - title이 null인 기존 알림은 body만 한 줄로 (이전 동작 유지)
                                                                                       
  ## 동작                                                                              
  
  | 케이스 | 결과 |                                                                    
  |---|---|                               
  | 앱 사용 중 (포그라운드) | 화면 안 sonner 토스트 표시 |                             
  | 앱 안 보는 중 (백그라운드) | OS 시스템 알림 표시 |                                 
  | 알림 클릭 (양쪽 모두) | 알림 페이지로 이동 |
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알림에 제목 필드를 추가하여 더 자세한 정보 전달 가능
  * 포그라운드 및 백그라운드 알림 처리 개선
  * 토스트를 통한 실시간 알림 표시 및 클릭하여 해당 페이지로 이동 기능

* **Bug Fixes**
  * 알림의 URL 검증을 통한 보안 강화

* **Chores**
  * 앱 이름 표기 정규화 (Feel-Log → FeelLog)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feel-log/feellog-frontend/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->