### PR TITLE
[FIX] 푸시알림 기능 수정

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -10,7 +10,7 @@ firebase.initializeApp({
   appId: '1:955303189262:web:291a97797f6c4a9cc3955f',
 });
 
-const messaging = firebase.messaging();
+firebase.messaging();
 
 const FALLBACK_URL = '/notification';
 
@@ -23,16 +23,6 @@ function toSafeInternalUrl(rawUrl) {
     return FALLBACK_URL;
   }
 }
-
-messaging.onBackgroundMessage((payload) => {
-  const title = payload.notification?.title || '알림';
-  const options = {
-    body: payload.notification?.body || '',
-    icon: '/svg/icon_bell.svg',
-    data: { url: toSafeInternalUrl(payload.data?.url) },
-  };
-  self.registration.showNotification(title, options);
-});
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { QueryProvider } from '@/shared/lib/QueryProvider';
 import { KakaoScript } from '@/shared/lib/KakaoScript';
 import { GoogleScript } from '@/shared/lib/GoogleScript';
 import { ForegroundMessageHandler } from '@/shared/lib/ForegroundMessageHandler';
+import { AutoRequestNotificationPermission } from '@/shared/lib/AutoRequestNotificationPermission';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -81,6 +82,7 @@ export default function RootLayout({
         <KakaoScript />
         <GoogleScript />
         <ForegroundMessageHandler />
+        <AutoRequestNotificationPermission />
         <BackgroundProvider>
           {children}
         </BackgroundProvider>

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -25,9 +25,14 @@ function MyPageContent() {
 
   const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
 
+  const isGuest = isLoaded && (!id || nickname.startsWith('guest'));
+
   const queryClient = useQueryClient();
-  const { data: settings } = useQuery(notificationQueries.settings());
-  const isPushNotificationEnabled = settings?.pushEnabled ?? false;
+  const { data: settings } = useQuery({
+    ...notificationQueries.settings(),
+    enabled: !isGuest,
+  });
+  const isPushNotificationEnabled = !isGuest && (settings?.pushEnabled ?? false);
 
   const updateSettingsMutation = useMutation({
     mutationFn: updateNotificationSettingsApi,
@@ -71,6 +76,10 @@ function MyPageContent() {
   }, [settings?.pushEnabled]);
 
   const handleTogglePush = async () => {
+    if (isGuest) {
+      setErrorBox(true);
+      return;
+    }
     if (isToggleProcessing || updateSettingsMutation.isPending) return;
     const next = !isPushNotificationEnabled;
     setIsToggleProcessing(true);
@@ -108,8 +117,6 @@ function MyPageContent() {
       setIsToggleProcessing(false);
     }
   };
-
-  const isGuest = isLoaded && (!id || nickname.startsWith('guest'));
 
   const handleAccountClick = () => {
     if (isGuest) {

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -32,7 +32,21 @@ function MyPageContent() {
     ...notificationQueries.settings(),
     enabled: !isGuest,
   });
-  const isPushNotificationEnabled = !isGuest && (settings?.pushEnabled ?? false);
+  const [notificationPermission, setNotificationPermission] =
+    useState<NotificationPermission | null>(null);
+
+  useEffect(() => {
+    if (typeof Notification === 'undefined') return;
+    setNotificationPermission(Notification.permission);
+    const handler = () => setNotificationPermission(Notification.permission);
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, []);
+
+  const isPushNotificationEnabled =
+    !isGuest &&
+    (settings?.pushEnabled ?? false) &&
+    notificationPermission === 'granted';
 
   const updateSettingsMutation = useMutation({
     mutationFn: updateNotificationSettingsApi,

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -30,7 +30,7 @@ function MyPageContent() {
   const queryClient = useQueryClient();
   const { data: settings } = useQuery({
     ...notificationQueries.settings(),
-    enabled: !isGuest,
+    enabled: isLoaded && !isGuest,
   });
   const [notificationPermission, setNotificationPermission] =
     useState<NotificationPermission | null>(null);

--- a/src/shared/lib/AutoRequestNotificationPermission.tsx
+++ b/src/shared/lib/AutoRequestNotificationPermission.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useUser } from '@/shared/store';
+import { postDeviceTokenApi } from '@/features/post-device-token';
+import { updateNotificationSettingsApi } from '@/entities/notification/api/notification-api';
+import { getFcmToken, requestNotificationPermission } from '@/shared/lib/firebase';
+
+export function AutoRequestNotificationPermission() {
+  const isLoaded = useUser((s) => s.isLoaded);
+  const id = useUser((s) => s.id);
+  const nickname = useUser((s) => s.nickname);
+  const triedRef = useRef(false);
+
+  useEffect(() => {
+    if (triedRef.current) return;
+    if (typeof window === 'undefined') return;
+    if (typeof Notification === 'undefined') return;
+    if (!isLoaded) return;
+    if (!id) return;
+    if (nickname.startsWith('guest')) return;
+    if (Notification.permission !== 'default') return;
+
+    triedRef.current = true;
+    (async () => {
+      try {
+        const permission = await requestNotificationPermission();
+        if (permission !== 'granted') return;
+        const fcmToken = await getFcmToken();
+        if (!fcmToken) return;
+        await postDeviceTokenApi({ token: fcmToken, deviceType: 'WEB' });
+        localStorage.setItem('fcmToken', fcmToken);
+        await updateNotificationSettingsApi({ pushEnabled: true });
+      } catch (error) {
+        console.error('알림 자동 권한 요청 실패:', error);
+      }
+    })();
+  }, [isLoaded, id, nickname]);
+
+  return null;
+}


### PR DESCRIPTION
## 변경                                                                         
                                                                                  
  ### 푸시 알림 중복 표시 수정                                                    
  - `firebase-messaging-sw.js`의 `onBackgroundMessage` 핸들러 제거                
  - 백엔드가 보내는 `notification` payload는 Chrome FCM이 자동으로 OS 알림 표시   
  - SW가 또 `showNotification` 호출하던 게 중복 원인이라 핸들러 자체를 제거       
  - `notificationclick` 핸들러는 유지 (자동 표시된 알림 클릭 시에도 작동)         
                                                                                  
  ### 첫 로그인 시 자동 권한 요청                                                 
  - `AutoRequestNotificationPermission` 컴포넌트 신규 (`shared/lib/`)             
  - layout에 등록하여 모든 페이지에서 한 번 시도                                  
  - 조건: 로그인 + 게스트 아님 + `Notification.permission === 'default'`          
  - 권한 허용 시 FCM 토큰 발급 + 백엔드 등록 + `settings.pushEnabled = true`      
  - ref로 세션당 한 번만 시도                                                     
                                                                                  
  ### 게스트 처리                                                                 
  - 게스트가 푸시 알림 토글 클릭 시 로그인 유도 모달 표시 (기존 다른 페이지와 동일 패턴)                                                                          
  - 게스트는 `notification-settings` 쿼리 호출 안 함 (`enabled: !isGuest`)        
  - 게스트는 토글 강제 OFF 표시
                                                                                  
  ### 권한 거부 시 토글 동기화            
  - 토글 표시 조건에 `Notification.permission === 'granted'` 추가                 
  - 권한 거부됐는데 백엔드 settings가 true인 불일치 케이스에서 토글 OFF로 표시    
  - `visibilitychange` 이벤트로 사용자가 브라우저 설정에서 권한 변경 후 탭 복귀 시 자동 반영                                                                      
                                                                                  
  ## 동작                                                                         
                                                                                  
  | 상황 | 결과 |                                                                 
  |---|---|                                                                       
  | 새 사용자 첫 로그인 | 자동 권한 팝업 → 허용 시 알림 ON |
  | 권한 거부 후 마이페이지 진입 | 토글 OFF 표시 (이전엔 ON으로 보이던 버그) |
  | 푸시 알림 수신 | 1번만 표시 (중복 해결) | 
  | 게스트 토글 클릭 | 로그인 유도 모달 |     
  | 게스트 마이페이지 진입 | 토글 강제 OFF, settings 쿼리 호출 안 함 |            
  | 브라우저 설정에서 권한 변경 후 탭 복귀 | 토글 표시 자동 갱신 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 앱 접속 후 푸시 알림 권한 자동 요청 기능 추가
  * 브라우저 알림 권한 상태 추적 및 관리 개선

* **버그 수정**
  * 게스트 사용자의 알림 설정 접근 제한
  * 알림 권한 미허용 시 푸시 알림 설정 활성화 차단

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feel-log/feellog-frontend/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->