### PR TITLE
[FIX] 모달 UI 피그마 스펙으로 수정

### DIFF
--- a/src/features/logout/ui/LogoutModal.tsx
+++ b/src/features/logout/ui/LogoutModal.tsx
@@ -16,7 +16,7 @@ export function LogoutModal({ isOpen, onClose }: LogoutModalProps) {
     <ConfirmModal
       type={"logoutCheck"}
       isOpen={isOpen}
-      title="로그아웃하시겠어요?"
+      title="로그아웃 하시겠어요?"
       confirmText="확인"
       cancelText="취소"
       onConfirm={() => logoutUser(accessToken!)}

--- a/src/shared/ui/ConfirmModal.tsx
+++ b/src/shared/ui/ConfirmModal.tsx
@@ -9,7 +9,6 @@ interface ConfirmModalProps {
   noCancel?: boolean;
   onConfirm: () => void;
   onCancel?: () => void;
-  isDangerous?: boolean;
 }
 
 export default function ConfirmModal({
@@ -23,7 +22,6 @@ export default function ConfirmModal({
   noCancel = false,
   onConfirm,
   onCancel,
-  isDangerous = false,
 }: ConfirmModalProps) {
   const visibilityClass = isOpen
     ? 'opacity-100 pointer-events-auto'
@@ -54,7 +52,7 @@ export default function ConfirmModal({
           <button
             type="button"
             onClick={onConfirm}
-            className="mt-8 flex h-10 w-[241px] cursor-pointer items-center justify-center rounded-[8px] bg-[#EB1C1C] text-[16px] font-medium leading-normal tracking-[-0.025em] text-white"
+            className="mt-8 flex h-10 w-[241px] cursor-pointer items-center justify-center rounded-[8px] bg-[#13278A] text-[16px] font-medium leading-normal tracking-[-0.025em] text-white"
           >
             {confirmText}
           </button>
@@ -68,20 +66,60 @@ export default function ConfirmModal({
             </button>
           )}
         </div>
-      ) : type === 'loginCheck' || type === 'logoutCheck' ? (
+      ) : type === 'logoutCheck' ? (
         <div
-          className={`box__container__2 fixed top-1/2 right-0 left-0 z-60 mx-auto h-auto w-70.75 -translate-y-1/2 rounded-[10px] bg-white px-5.25 pt-12.25 pb-5 transition-opacity duration-200 ${visibilityClass}`}
+          className={`fixed top-1/2 right-0 left-0 z-60 mx-auto flex h-[202px] w-[283px] -translate-y-1/2 flex-col items-center rounded-[10px] bg-white px-[21px] pt-[44px] pb-5 transition-opacity duration-200 ${visibilityClass}`}
         >
-          <span className={'mb-1 block text-center text-[14px] font-bold'}>{title}</span>
-          <span className={'text-ray-600 mb-8 block text-center text-[14px]'}>{secondary}</span>
-          <div className={'button__wrapper flex flex-col gap-2'}>
-            <button className="rounded-[8px] py-2 text-[14px] text-white bg-[#13278a] hover:bg-[#0f1f66]" onClick={onConfirm}>
-              {confirmText}
-            </button>
-            <button className={'text-[14px] py-2 text-black rounded-[8px]'} onClick={onCancel}>
+          <span className="text-center text-[16px] font-semibold leading-normal tracking-[-0.025em] text-black">
+            {title}
+          </span>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="mt-[43px] flex h-10 w-[241px] cursor-pointer items-center justify-center rounded-[8px] bg-[#13278A] text-[16px] font-medium leading-normal tracking-[-0.025em] text-white"
+          >
+            {confirmText}
+          </button>
+          {!noCancel && onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="mt-[7px] cursor-pointer text-[16px] font-medium leading-normal tracking-[-0.025em] text-[#73787E]"
+            >
               {cancelText}
             </button>
+          )}
+        </div>
+      ) : type === 'loginCheck' ? (
+        <div
+          className={`fixed top-1/2 right-0 left-0 z-60 mx-auto flex h-[222px] w-[283px] -translate-y-1/2 flex-col items-center rounded-[10px] bg-white px-[21px] pt-[49px] pb-5 transition-opacity duration-200 ${visibilityClass}`}
+        >
+          <div className="flex flex-col items-center gap-[5px]">
+            <span className="text-center text-[16px] font-semibold leading-normal tracking-[-0.025em] text-black">
+              {title}
+            </span>
+            {(secondary ?? message) && (
+              <span className="text-center text-[14px] font-medium leading-normal tracking-[-0.025em] text-[#474C52]">
+                {secondary ?? message}
+              </span>
+            )}
           </div>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="mt-8 flex h-10 w-[241px] cursor-pointer items-center justify-center rounded-[8px] bg-[#13278A] text-[16px] font-medium leading-normal tracking-[-0.025em] text-white"
+          >
+            {confirmText}
+          </button>
+          {!noCancel && onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="mt-[7px] cursor-pointer text-[16px] font-medium leading-normal tracking-[-0.025em] text-[#73787E]"
+            >
+              {cancelText}
+            </button>
+          )}
         </div>
       ) : (
         <div
@@ -109,9 +147,7 @@ export default function ConfirmModal({
               </button>
             )}
             <button
-              className={`flex-1 rounded-[8px] py-2.5 text-[14px] font-medium text-white transition-colors ${
-                isDangerous ? 'bg-[#eb1c1c] hover:bg-[#d41a1a]' : 'bg-[#13278a] hover:bg-[#0f1f66]'
-              }`}
+              className="flex-1 rounded-[8px] bg-[#13278a] py-2.5 text-[14px] font-medium text-white transition-colors hover:bg-[#0f1f66]"
               onClick={onConfirm}
             >
               {confirmText}


### PR DESCRIPTION
## 변경                                                                         
                                                                                  
  ### 삭제 모달 (deleteCheck)                                                     
  - 확인 버튼 색상 변경: 빨강 `#EB1C1C` → 남색 `#13278A`                          
  - 디자인 시안 통일                                                              
                                              
  ### 로그아웃 모달 (logoutCheck)                                                 
  - `loginCheck`와 같은 분기에 묶여있던 것을 별도 분기로 분리                     
  - 피그마 스펙 적용
  - 제목 띄어쓰기 수정           
                                                                                  
  ### 로그인 유도 모달 (loginCheck)                                               
  - 피그마 스펙 적용                                                                       
  - 기존 작은 흰색 박스 디자인에서 deleteCheck와 동일한 디자인 언어로 통일        
                                                                                  
  ### 죽은 코드 정리                                                              
  - `isDangerous` prop 제거
  - 빨강 분기도 같이 제거 (어차피 항상 false 쪽으로 분기됨)                       
                                                                                  
  ## 영향받는 페이지                                                              
                                                                                  
  **삭제 모달**: 캘린더 / 자산 상세 / 내보내기                                    
  **로그아웃 모달**                                                
  **로그인 유도 모달**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 로그아웃 확인 모달의 메시지 표기가 개선되었습니다.
  * 모달 버튼 스타일이 정리되고 일관성 있게 통합되었습니다.
  * 로그인/로그아웃 확인 모달의 레이아웃이 최적화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feel-log/feellog-frontend/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->