### PR TITLE
[FIX] 서비스 워커 즉시 활성화 및 토큰 발급 시 활성 워커 대기

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -12,6 +12,14 @@ firebase.initializeApp({
 
 firebase.messaging();
 
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
 const FALLBACK_URL = '/notification';
 
 function toSafeInternalUrl(rawUrl) {

--- a/src/shared/lib/firebase.ts
+++ b/src/shared/lib/firebase.ts
@@ -35,7 +35,8 @@ export async function getFcmToken(): Promise<string | null> {
     const messaging = getMessagingInstance();
     if (!messaging || !VAPID_KEY) return null;
 
-    const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js');
+    await navigator.serviceWorker.register('/firebase-messaging-sw.js');
+    const registration = await navigator.serviceWorker.ready;
     const token = await getToken(messaging, {
       vapidKey: VAPID_KEY,
       serviceWorkerRegistration: registration,


### PR DESCRIPTION
## 작업 내용

  푸시 알림이 OS 레벨에서 2번 표시되는 문제를 보강합니다.
  (핵심 원인인 SW `onBackgroundMessage` 중복 표시는 #180에서 이미 제거됨. 본 PR은 후속 보강)

  ### 1. 서비스 워커 즉시 활성화 (`public/firebase-messaging-sw.js`)
  - `install` → `skipWaiting()`, `activate` → `clients.claim()` 추가
  - 새 SW가 기존 SW를 즉시 대체하도록 처리. 기존엔 모든 탭/PWA가 닫히기 전까지 옛 SW가 활성
  상태로 남아, 이미 제거된 `onBackgroundMessage` 버전 SW가 살아있으면 알림이 2번 표시될 수 있었음.

  ### 2. 토큰 발급 시 활성 워커 대기 (`src/shared/lib/firebase.ts`)
  - `getFcmToken`에서 `serviceWorker.register()` 직후 `navigator.serviceWorker.ready`로 SW가 활성될 때까지 대기한 뒤 `getToken` 호출
  - SW가 막 등록되는 순간(예: unregister 직후) 발생하던 `AbortError: ... no active Service Worker` 토큰 발급 실패 방지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 서비스 워커 초기화 및 활성화 로직을 개선하여 더 빠른 업데이트 적용 및 클라이언트 제어 확보
  * Firebase 메시징 토큰 등록 전 서비스 워커 명시적 등록을 통해 알림 서비스의 안정성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feel-log/feellog-frontend/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->